### PR TITLE
DRTII-989 LTN does not have an estimated chox time

### DIFF
--- a/shared/src/main/scala/uk/gov/homeoffice/drt/ports/config/Ltn.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/ports/config/Ltn.scala
@@ -44,6 +44,7 @@ object Ltn extends AirportConfigLike {
       )
     ),
     eGateBankSizes = Map(T1 -> Iterable(10, 5)),
+    hasEstChox = false,
     role = LTN,
     terminalPaxTypeQueueAllocation = Map(
       T1 -> (defaultQueueRatios + (EeaMachineReadable -> List(


### PR DESCRIPTION
Set LTN to not show the estimated chox column as the data is not in their feed