### PR TITLE
Drtii 1047 historic manifests lookups are too slow

### DIFF
--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/protobuf/Serializer.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/protobuf/Serializer.scala
@@ -16,7 +16,7 @@ import uk.gov.homeoffice.drt.protobuf.messages.RegisteredArrivalMessage.{Registe
 import uk.gov.homeoffice.drt.protobuf.messages.ShiftMessage.{ShiftMessage, ShiftStateSnapshotMessage, ShiftsMessage}
 import uk.gov.homeoffice.drt.protobuf.messages.StaffMovementMessages.{RemoveStaffMovementMessage, StaffMovementMessage, StaffMovementsMessage, StaffMovementsStateSnapshotMessage}
 import uk.gov.homeoffice.drt.protobuf.messages.TerminalQueuesSummary.TerminalQueuesSummaryMessage
-import uk.gov.homeoffice.drt.protobuf.messages.VoyageManifest.{VoyageManifestLatestFileNameMessage, VoyageManifestMessage, VoyageManifestStateSnapshotMessage, VoyageManifestsMessage}
+import uk.gov.homeoffice.drt.protobuf.messages.VoyageManifest.{ManifestLikeMessage, ManifestPassengerProfileMessage, MaybeManifestLikeMessage, VoyageManifestLatestFileNameMessage, VoyageManifestMessage, VoyageManifestStateSnapshotMessage, VoyageManifestsMessage}
 
 class Serializer extends SerializerWithStringManifest {
   override def identifier: Int = 9001
@@ -75,6 +75,9 @@ class Serializer extends SerializerWithStringManifest {
   final val NeboArrival: String = classOf[NeboArrivalMessage].getName
   final val NeboArrivalSnapshot: String = classOf[NeboArrivalSnapshotMessage].getName
   final val ModelAndFeatures: String = classOf[ModelAndFeaturesMessage].getName
+  final val MaybeManifestLike: String = classOf[MaybeManifestLikeMessage].getName
+  final val ManifestLike: String = classOf[ManifestLikeMessage].getName
+  final val ManifestPassengerProfile: String = classOf[ManifestPassengerProfileMessage].getName
 
   override def toBinary(objectToSerialize: AnyRef): Array[Byte] = objectToSerialize match {
     case m: GeneratedMessage => m.toByteArray
@@ -134,6 +137,9 @@ class Serializer extends SerializerWithStringManifest {
       case NeboArrival => NeboArrivalMessage.parseFrom(bytes)
       case NeboArrivalSnapshot => NeboArrivalSnapshotMessage.parseFrom(bytes)
       case ModelAndFeatures => ModelAndFeaturesMessage.parseFrom(bytes)
+      case MaybeManifestLike => MaybeManifestLikeMessage.parseFrom(bytes)
+      case ManifestLike => ManifestLikeMessage.parseFrom(bytes)
+      case ManifestPassengerProfile => ManifestPassengerProfileMessage.parseFrom(bytes)
     }
   }
 }

--- a/proto/src/main/protobuf/VoyageManifest.proto
+++ b/proto/src/main/protobuf/VoyageManifest.proto
@@ -23,7 +23,7 @@ message VoyageManifestsMessage {
 }
 
 message MaybeVoyageManifestMessage {
-    optional VoyageManifestMessage maybeVoyageManifest = 1;
+    optional ManifestLikeMessage maybeVoyageManifest = 1;
 }
 
 message VoyageManifestMessage {
@@ -38,6 +38,18 @@ message VoyageManifestMessage {
     repeated PassengerInfoJsonMessage passengerList = 9;
 }
 
+message ManifestLikeMessage {
+    optional int64 createdAt = 1;
+    optional string eventCode = 2;
+    optional string arrivalPortCode = 3;
+    optional string departurePortCode = 4;
+    optional string voyageNumber = 5;
+    optional string carrierCode = 6;
+    optional string scheduledDateOfArrival = 7;
+    optional string scheduledTimeOfArrival = 8;
+    repeated ManifestPassengerProfileMessage passengerList = 9;
+}
+
 message PassengerInfoJsonMessage {
     optional string documentType = 1;
     optional string documentIssuingCountryCode = 2;
@@ -49,3 +61,12 @@ message PassengerInfoJsonMessage {
     optional string nationalityCountryCode = 8;
     optional string passengerIdentifier = 9;
 }
+
+message ManifestPassengerProfileMessage {
+    optional string nationality = 1;
+    optional string documentType = 2;
+    optional string age = 3;
+    optional bool inTransit = 4;
+    optional string passengerIdentifier = 5;
+}
+

--- a/proto/src/main/protobuf/VoyageManifest.proto
+++ b/proto/src/main/protobuf/VoyageManifest.proto
@@ -40,14 +40,15 @@ message VoyageManifestMessage {
 
 message ManifestLikeMessage {
     optional int64 createdAt = 1;
-    optional string eventCode = 2;
-    optional string arrivalPortCode = 3;
-    optional string departurePortCode = 4;
-    optional string voyageNumber = 5;
-    optional string carrierCode = 6;
-    optional string scheduledDateOfArrival = 7;
-    optional string scheduledTimeOfArrival = 8;
-    repeated ManifestPassengerProfileMessage passengerList = 9;
+    optional string splitSource = 2;
+    optional string eventCode = 3;
+    optional string arrivalPortCode = 4;
+    optional string departurePortCode = 5;
+    optional string voyageNumber = 6;
+    optional string carrierCode = 7;
+    optional string scheduledDateOfArrival = 8;
+    optional string scheduledTimeOfArrival = 9;
+    repeated ManifestPassengerProfileMessage passengerList = 10;
 }
 
 message PassengerInfoJsonMessage {

--- a/proto/src/main/protobuf/VoyageManifest.proto
+++ b/proto/src/main/protobuf/VoyageManifest.proto
@@ -23,7 +23,8 @@ message VoyageManifestsMessage {
 }
 
 message MaybeManifestLikeMessage {
-    optional ManifestLikeMessage maybeVoyageManifest = 1;
+    optional int64 createdAt = 1;
+    optional ManifestLikeMessage maybeVoyageManifest = 2;
 }
 
 message VoyageManifestMessage {

--- a/proto/src/main/protobuf/VoyageManifest.proto
+++ b/proto/src/main/protobuf/VoyageManifest.proto
@@ -22,7 +22,7 @@ message VoyageManifestsMessage {
     repeated VoyageManifestMessage manifestMessages = 2;
 }
 
-message MaybeVoyageManifestMessage {
+message MaybeManifestLikeMessage {
     optional ManifestLikeMessage maybeVoyageManifest = 1;
 }
 

--- a/proto/src/main/protobuf/VoyageManifest.proto
+++ b/proto/src/main/protobuf/VoyageManifest.proto
@@ -22,6 +22,10 @@ message VoyageManifestsMessage {
     repeated VoyageManifestMessage manifestMessages = 2;
 }
 
+message MaybeVoyageManifestMessage {
+    optional VoyageManifestMessage maybeVoyageManifest = 1;
+}
+
 message VoyageManifestMessage {
     optional int64 createdAt = 1;
     optional string eventCode = 2;

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/EventType.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/EventType.scala
@@ -8,7 +8,7 @@ import upickle.default.{ReadWriter, macroRW}
 sealed trait EventType extends ClassNameForToString
 
 object EventType {
-  implicit val rw: default.ReadWriter[EventType] = ReadWriter.merge(macroRW[DC.type], macroRW[CI.type])
+  implicit val rw: default.ReadWriter[EventType] = ReadWriter.merge(macroRW[DC.type], macroRW[CI.type], macroRW[InvalidEventType.type])
 
   def apply(eventType: String): EventType = eventType match {
     case "DC" => DC

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/Splits.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/Splits.scala
@@ -1,9 +1,13 @@
 package uk.gov.homeoffice.drt.arrivals
 
+import ujson.Value.Value
 import uk.gov.homeoffice.drt.arrivals.SplitStyle.PaxNumbers
 import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSource
 import uk.gov.homeoffice.drt.ports.{ApiPaxTypeAndQueueCount, Queues}
-import upickle.default.{ReadWriter, macroRW}
+import upickle.default.{ReadWriter, macroRW, read, readwriter, writeJs}
+
+import scala.collection.mutable
+import scala.util.Try
 
 case class Splits(splits: Set[ApiPaxTypeAndQueueCount],
                   source: SplitSource,
@@ -20,5 +24,21 @@ object Splits {
     s.paxCount
   }).sum
 
-  implicit val rw: ReadWriter[Splits] = macroRW
+  implicit val splitsReadWriter: ReadWriter[Splits] =
+    readwriter[Value].bimap[Splits](
+      (splits: Splits) => ujson.Obj(mutable.LinkedHashMap(
+          "splits" -> Try(writeJs(splits.splits)).getOrElse(throw new Exception(s"Failed to write splits.splits: ${splits.splits}")),
+          "source" -> Try(writeJs(splits.source)).getOrElse(throw new Exception(s"Failed to write splits.source: ${splits.source}")),
+          "maybeEventType" -> Try(writeJs(splits.maybeEventType)).getOrElse(throw new Exception(s"Failed to write splits.maybeEventType: ${splits.maybeEventType}")),
+          "splitStyle" -> Try(writeJs(splits.splitStyle)).getOrElse(throw new Exception(s"Failed to write splits.splitStyle: ${splits.splitStyle}")),
+        ))
+      ,
+      json => {
+        val splits = read[Set[ApiPaxTypeAndQueueCount]](json("splits"))
+        val source = read[SplitSource](json("source"))
+        val maybeEventType = read[Option[EventType]](json("maybeEventType"))
+        val splitStyle = read[SplitStyle](json("splitStyle"))
+        Splits(splits, source, maybeEventType, splitStyle)
+      }
+    )
 }

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/Splits.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/Splits.scala
@@ -31,8 +31,8 @@ object Splits {
           "source" -> Try(writeJs(splits.source)).getOrElse(throw new Exception(s"Failed to write splits.source: ${splits.source}")),
           "maybeEventType" -> Try(writeJs(splits.maybeEventType)).getOrElse(throw new Exception(s"Failed to write splits.maybeEventType: ${splits.maybeEventType}")),
           "splitStyle" -> Try(writeJs(splits.splitStyle)).getOrElse(throw new Exception(s"Failed to write splits.splitStyle: ${splits.splitStyle}")),
-        ))
-      ,
+        )
+      ),
       json => {
         val splits = read[Set[ApiPaxTypeAndQueueCount]](json("splits"))
         val source = read[SplitSource](json("source"))

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/SplitsTest.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/SplitsTest.scala
@@ -1,0 +1,31 @@
+package uk.gov.homeoffice.drt.arrivals
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.homeoffice.drt.Nationality
+import uk.gov.homeoffice.drt.arrivals.EventTypes.DC
+import uk.gov.homeoffice.drt.arrivals.SplitStyle.PaxNumbers
+import uk.gov.homeoffice.drt.ports.PaxTypes.GBRNational
+import uk.gov.homeoffice.drt.ports.Queues.EeaDesk
+import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources
+import uk.gov.homeoffice.drt.ports.{ApiPaxTypeAndQueueCount, PaxAge}
+import upickle.default.{read, writeJs}
+
+class SplitsTest extends AnyWordSpec with Matchers {
+  "Splits" should {
+    "serialise to json and back" in {
+      val splits = Splits(
+        Set(ApiPaxTypeAndQueueCount(GBRNational, EeaDesk, 1, Option(Map(Nationality("GBR") -> 1)), Option(Map(PaxAge(25) -> 1)))),
+        SplitSources.Historical,
+        Option(DC),
+        PaxNumbers
+      )
+      val serialised = writeJs(splits)
+      val deserialised = read[Splits](serialised)
+
+      println(s"deserialised: $deserialised")
+
+      deserialised shouldBe splits
+    }
+  }
+}

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/SplitsTest.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/SplitsTest.scala
@@ -3,7 +3,7 @@ package uk.gov.homeoffice.drt.arrivals
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.homeoffice.drt.Nationality
-import uk.gov.homeoffice.drt.arrivals.EventTypes.DC
+import uk.gov.homeoffice.drt.arrivals.EventTypes.{DC, InvalidEventType}
 import uk.gov.homeoffice.drt.arrivals.SplitStyle.PaxNumbers
 import uk.gov.homeoffice.drt.ports.PaxTypes.GBRNational
 import uk.gov.homeoffice.drt.ports.Queues.EeaDesk
@@ -23,7 +23,18 @@ class SplitsTest extends AnyWordSpec with Matchers {
       val serialised = writeJs(splits)
       val deserialised = read[Splits](serialised)
 
-      println(s"deserialised: $deserialised")
+      deserialised shouldBe splits
+    }
+
+    "serialise to json and back when there's an InvalidEventType" in {
+      val splits = Splits(
+        Set(ApiPaxTypeAndQueueCount(GBRNational, EeaDesk, 1, Option(Map(Nationality("GBR") -> 1)), Option(Map(PaxAge(25) -> 1)))),
+        SplitSources.Historical,
+        Option(InvalidEventType),
+        PaxNumbers
+      )
+      val serialised = writeJs(splits)
+      val deserialised = read[Splits](serialised)
 
       deserialised shouldBe splits
     }


### PR DESCRIPTION
Add protobuf messages for persisting `ManifestLike`s
Add to protobuf serialisation config
Fix `EventType`'s upickle serialisation to include `InvalidEventType`
Add regression test around this