### PR TITLE
Drtii 632 alternative wait times with queue size

### DIFF
--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/protobuf/Serializer.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/protobuf/Serializer.scala
@@ -78,6 +78,8 @@ class Serializer extends SerializerWithStringManifest {
   final val MaybeManifestLike: String = classOf[MaybeManifestLikeMessage].getName
   final val ManifestLike: String = classOf[ManifestLikeMessage].getName
   final val ManifestPassengerProfile: String = classOf[ManifestPassengerProfileMessage].getName
+  final val PassengersMinute: String = classOf[PassengersMinuteMessage].getName
+  final val PassengersMinutes: String = classOf[PassengersMinutesMessage].getName
 
   override def toBinary(objectToSerialize: AnyRef): Array[Byte] = objectToSerialize match {
     case m: GeneratedMessage => m.toByteArray
@@ -139,7 +141,8 @@ class Serializer extends SerializerWithStringManifest {
       case ModelAndFeatures => ModelAndFeaturesMessage.parseFrom(bytes)
       case MaybeManifestLike => MaybeManifestLikeMessage.parseFrom(bytes)
       case ManifestLike => ManifestLikeMessage.parseFrom(bytes)
-      case ManifestPassengerProfile => ManifestPassengerProfileMessage.parseFrom(bytes)
+      case PassengersMinute => PassengersMinuteMessage.parseFrom(bytes)
+      case PassengersMinutes => PassengersMinutesMessage.parseFrom(bytes)
     }
   }
 }

--- a/proto/src/main/protobuf/CrunchState.proto
+++ b/proto/src/main/protobuf/CrunchState.proto
@@ -100,6 +100,7 @@ message PassengersMinuteMessage {
     optional string queueName = 1;
     optional int64 minute = 2;
     repeated double passengers = 3;
+    optional int64 lastUpdated = 4;
 }
 
 message PassengersMinutesMessage {

--- a/proto/src/main/protobuf/CrunchState.proto
+++ b/proto/src/main/protobuf/CrunchState.proto
@@ -97,14 +97,14 @@ message CrunchMinuteMessage {
 }
 
 message PassengersMinuteMessage {
-    optional string queueName = 1;
-    optional int64 minute = 2;
-    repeated double passengers = 3;
-    optional int64 lastUpdated = 4;
+    optional int64 minute = 1;
+    repeated double passengers = 2;
 }
 
 message PassengersMinutesMessage {
-    repeated PassengersMinuteMessage minutes = 1;
+    optional string queueName = 1;
+    repeated PassengersMinuteMessage minutes = 2;
+    optional int64 lastUpdated = 3;
 }
 
 message StaffMinutesMessage {

--- a/proto/src/main/protobuf/CrunchState.proto
+++ b/proto/src/main/protobuf/CrunchState.proto
@@ -96,8 +96,10 @@ message CrunchMinuteMessage {
     optional int32 maybeDeployedPaxInQueue = 14;
 }
 
-message PassengersMessage {
-    repeated double passengers = 1;
+message PassengersMinuteMessage {
+    optional string queueName = 1;
+    optional int64 minute = 2;
+    repeated double passengers = 3;
 }
 
 message StaffMinutesMessage {

--- a/proto/src/main/protobuf/CrunchState.proto
+++ b/proto/src/main/protobuf/CrunchState.proto
@@ -94,6 +94,15 @@ message CrunchMinuteMessage {
     optional int64 lastUpdated = 12;
     optional int32 maybePaxInQueue = 13;
     optional int32 maybeDeployedPaxInQueue = 14;
+    optional PassengersMessage passengers = 15;
+}
+
+message PassengersMessage {
+    repeated PassengerMessage passengers = 1;
+}
+
+message PassengerMessage {
+    optional double load = 1;
 }
 
 message StaffMinutesMessage {

--- a/proto/src/main/protobuf/CrunchState.proto
+++ b/proto/src/main/protobuf/CrunchState.proto
@@ -97,14 +97,14 @@ message CrunchMinuteMessage {
 }
 
 message PassengersMinuteMessage {
-    optional int64 minute = 1;
-    repeated double passengers = 2;
+    optional string queueName = 1;
+    optional int64 minute = 2;
+    repeated double passengers = 3;
+    optional int64 lastUpdated = 4;
 }
 
 message PassengersMinutesMessage {
-    optional string queueName = 1;
-    repeated PassengersMinuteMessage minutes = 2;
-    optional int64 lastUpdated = 3;
+    repeated PassengersMinuteMessage minutes = 1;
 }
 
 message StaffMinutesMessage {

--- a/proto/src/main/protobuf/CrunchState.proto
+++ b/proto/src/main/protobuf/CrunchState.proto
@@ -92,6 +92,8 @@ message CrunchMinuteMessage {
     optional int32 actDesks = 10;
     optional int32 actWait = 11;
     optional int64 lastUpdated = 12;
+    optional int32 maybePaxInQueue = 13;
+    optional int32 maybeDeployedPaxInQueue = 14;
 }
 
 message StaffMinutesMessage {

--- a/proto/src/main/protobuf/CrunchState.proto
+++ b/proto/src/main/protobuf/CrunchState.proto
@@ -94,15 +94,10 @@ message CrunchMinuteMessage {
     optional int64 lastUpdated = 12;
     optional int32 maybePaxInQueue = 13;
     optional int32 maybeDeployedPaxInQueue = 14;
-    optional PassengersMessage passengers = 15;
 }
 
 message PassengersMessage {
-    repeated PassengerMessage passengers = 1;
-}
-
-message PassengerMessage {
-    optional double load = 1;
+    repeated double passengers = 1;
 }
 
 message StaffMinutesMessage {

--- a/proto/src/main/protobuf/CrunchState.proto
+++ b/proto/src/main/protobuf/CrunchState.proto
@@ -102,6 +102,10 @@ message PassengersMinuteMessage {
     repeated double passengers = 3;
 }
 
+message PassengersMinutesMessage {
+    repeated PassengersMinuteMessage minutes = 1;
+}
+
 message StaffMinutesMessage {
     repeated StaffMinuteMessage minutes = 1;
 }

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/ports/PaxTypes.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/ports/PaxTypes.scala
@@ -86,6 +86,8 @@ object PaxTypes {
   }
 
   def displayNameShort(pt: PaxType): String = pt match {
+    case GBRNational => "GBR"
+    case GBRNationalBelowEgateAge => "GBR U12"
     case EeaMachineReadable => "EEA MR"
     case EeaNonMachineReadable => "EEA NMR"
     case EeaBelowEGateAge => "EEA U12"


### PR DESCRIPTION
Add missing short descriptions for GBR pax
Add `PassengersMinuteMessage` for persisting passenger loads at any given terminal, queue & minute