### PR TITLE
DRTII-1104 Fix case with live feed without pax

### DIFF
--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ApiArrivalsWithSplits.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ApiArrivalsWithSplits.scala
@@ -78,7 +78,14 @@ case class ApiFlightWithSplits(apiFlight: Arrival, splits: Set[Splits], lastUpda
 
   def hasValidApi: Boolean = {
     val maybeApiSplits = splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages)
-    val hasLiveSource = apiFlight.FeedSources.contains(LiveFeedSource)
+    val totalPaxSourceIntroductionMillis = 1655247600000L // 2022-06-15 midnight BST
+
+    val paxSourceAvailable = apiFlight.Scheduled >= totalPaxSourceIntroductionMillis
+    val hasLiveSource = if (paxSourceAvailable)
+      apiFlight.TotalPax.exists(tp => tp.feedSource == LiveFeedSource && tp.pax.nonEmpty)
+    else
+      apiFlight.FeedSources.contains(LiveFeedSource)
+
     val hasSimulationSource = apiFlight.FeedSources.contains(ScenarioSimulationSource)
     (maybeApiSplits, hasLiveSource, hasSimulationSource) match {
       case (Some(_), _, true) => true

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ApiFlightWithSplitsSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ApiFlightWithSplitsSpec.scala
@@ -9,38 +9,40 @@ import uk.gov.homeoffice.drt.splits.ApiSplitsToSplitRatio
 
 class ApiFlightWithSplitsSpec extends Specification {
   "A flight with splits" should {
+    val scheduledAfterPaxSources = 1655247600000L
+    val scheduledBeforePaxSources = scheduledAfterPaxSources - 1000
     "have valid Api when api splits pax count is within the 5% Threshold of LiveSourceFeed pax count" in {
       "and there are no transfer pax" in {
         val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 41, 0, Set(LiveFeedSource),
-          Set(TotalPaxSource(Option(40), LiveFeedSource)))
+          Set(TotalPaxSource(Option(40), LiveFeedSource)), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
         flightWithSplits.isWithinThreshold(apiSplits) mustEqual true
         flightWithSplits.hasValidApi mustEqual true
       }
 
       "and there are transfer pax only in the port feed data" in {
-        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 20, 21, 0, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)))
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 20, 21, 0, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
         flightWithSplits.isWithinThreshold(apiSplits) mustEqual true
         flightWithSplits.hasValidApi mustEqual true
       }
 
       "and there are transfer pax only in the API data" in {
-        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 41, 20, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)))
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 41, 20, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
         flightWithSplits.isWithinThreshold(apiSplits) mustEqual true
         flightWithSplits.hasValidApi mustEqual true
       }
 
       "and there are transfer pax both in the API data and in the port feed" in {
-        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 20, 21, 20, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)))
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 20, 21, 20, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(s => s.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
         flightWithSplits.isWithinThreshold(apiSplits) mustEqual true
         flightWithSplits.hasValidApi mustEqual true
       }
 
       "or there is a ScenarioSimulationSource" in {
-        val flightWithSplits = flightWithPaxAndApiSplits(Option(20), 0, 41, 0, Set(LiveFeedSource, ScenarioSimulationSource), Set())
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(20), 0, 41, 0, Set(LiveFeedSource, ScenarioSimulationSource), Set(), scheduledAfterPaxSources)
 
         flightWithSplits.hasValidApi mustEqual true
       }
@@ -48,28 +50,28 @@ class ApiFlightWithSplitsSpec extends Specification {
 
     "not have valid Api when api splits pax count outside the 5% Threshold of LiveSourceFeed pax count" in {
       "and there are no transfer pax" in {
-        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 45, 0, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)))
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 45, 0, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
         flightWithSplits.isWithinThreshold(apiSplits) mustEqual false
         flightWithSplits.hasValidApi mustEqual false
       }
 
       "and there are transfer pax only in the port feed data" in {
-        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 20, 24, 0, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)))
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 20, 24, 0, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
         flightWithSplits.isWithinThreshold(apiSplits) mustEqual false
         flightWithSplits.hasValidApi mustEqual false
       }
 
       "and there are transfer pax only in the API data" in {
-        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 21, 25, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)))
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 21, 25, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
         flightWithSplits.isWithinThreshold(apiSplits) mustEqual false
         flightWithSplits.hasValidApi mustEqual false
       }
 
       "and there are transfer pax both in the API data and in the port feed" in {
-        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 20, 25, 25, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)))
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 20, 25, 25, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(s => s.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
         flightWithSplits.isWithinThreshold(apiSplits) mustEqual false
         flightWithSplits.hasValidApi mustEqual false
@@ -81,20 +83,35 @@ class ApiFlightWithSplitsSpec extends Specification {
       flightWithSplits.hasValidApi mustEqual false
     }
 
-    "have valid Api splits when flight is has no LiveFeedSource" in {
+    "have valid Api splits when flight has a LiveFeedSource and a Live TotalPaxSource containing no passenger numbers" in {
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(100), 0, 40, 0, Set(LiveFeedSource), Set(TotalPaxSource(None, LiveFeedSource)), scheduledAfterPaxSources)
+        flightWithSplits.hasValidApi mustEqual true
+    }
+
+    "have valid Api splits when flight has a LiveFeedSource and no Live TotalPaxSource" in {
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(100), 0, 40, 0, Set(LiveFeedSource), Set(), scheduledAfterPaxSources)
+        flightWithSplits.hasValidApi mustEqual true
+    }
+
+    "have no valid Api splits when flight scheduled before pax sources were recorded has a LiveFeedSource and ActPax more than 5% different to API pax" in {
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(100), 0, 40, 0, Set(LiveFeedSource), Set(), scheduledBeforePaxSources)
+        flightWithSplits.hasValidApi mustEqual false
+    }
+
+    "have valid Api splits when flight has no LiveFeedSource" in {
       "and pax count differences are within the threshold" in {
-        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 40, 0, Set(), Set())
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 40, 0, Set(), Set(), scheduledAfterPaxSources)
         flightWithSplits.hasValidApi mustEqual true
       }
       "and pax count differences are outside the threshold" in {
-        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 100, 0, Set(), Set())
+        val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 100, 0, Set(), Set(), scheduledAfterPaxSources)
         flightWithSplits.hasValidApi mustEqual true
       }
     }
 
     "when there no actual pax number in liveFeed" in {
       "and api splits has pax number and hasValidApi is true" in {
-        val flightWithSplits = flightWithPaxAndApiSplits(None, 0, 100, 0, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)))
+        val flightWithSplits = flightWithPaxAndApiSplits(None, 0, 100, 0, Set(LiveFeedSource), Set(TotalPaxSource(Option(40), LiveFeedSource)), scheduledAfterPaxSources)
         flightWithSplits.hasValidApi mustEqual true
         flightWithSplits.pcpPaxEstimate.pax must beSome(100)
         val paxPerQueue: Option[Map[Queues.Queue, Int]] = ApiSplitsToSplitRatio.paxPerQueueUsingBestSplitsAsRatio(flightWithSplits)
@@ -103,17 +120,17 @@ class ApiFlightWithSplitsSpec extends Specification {
     }
 
     "give a pax count from splits when it has API splits" in {
-      val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 45, 0, Set(), Set())
+      val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 45, 0, Set(), Set(), scheduledAfterPaxSources)
       flightWithSplits.totalPaxFromApiExcludingTransfer.flatMap(_.pax) mustEqual Option(45)
     }
 
     "give a pax count from splits when it has API splits which does not include transfer pax" in {
-      val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 45, 20, Set(), Set())
+      val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 45, 20, Set(), Set(), scheduledAfterPaxSources)
       flightWithSplits.totalPaxFromApiExcludingTransfer.flatMap(_.pax) mustEqual Option(45)
     }
 
     "give a pax count from splits when it has API splits even when it is outside the trusted threshold" in {
-      val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 150, 0, Set(LiveFeedSource), Set())
+      val flightWithSplits = flightWithPaxAndApiSplits(Option(40), 0, 150, 0, Set(LiveFeedSource), Set(), scheduledAfterPaxSources)
       flightWithSplits.totalPaxFromApiExcludingTransfer.flatMap(_.pax) mustEqual Option(150)
     }
 
@@ -133,8 +150,15 @@ class ApiFlightWithSplitsSpec extends Specification {
     }
   }
 
-  private def flightWithPaxAndApiSplits(actPax: Option[Int], transferPax: Int, splitsDirect: Int, splitsTransfer: Int, sources: Set[FeedSource], totalPax: Set[TotalPaxSource]): ApiFlightWithSplits = {
-    val flight: Arrival = ArrivalGenerator.arrival(actPax = actPax, tranPax = Option(transferPax), feedSources = sources, totalPax = totalPax)
+  private def flightWithPaxAndApiSplits(actPax: Option[Int],
+                                        transferPax: Int,
+                                        splitsDirect: Int,
+                                        splitsTransfer: Int,
+                                        sources: Set[FeedSource],
+                                        totalPax: Set[TotalPaxSource],
+                                        scheduled: Long,
+                                       ): ApiFlightWithSplits = {
+    val flight: Arrival = ArrivalGenerator.arrival(actPax = actPax, tranPax = Option(transferPax), feedSources = sources, totalPax = totalPax, sch = scheduled)
 
     ApiFlightWithSplits(flight, Set(splitsForPax(directPax = splitsDirect, transferPax = splitsTransfer, ApiSplitsWithHistoricalEGateAndFTPercentages)))
   }


### PR DESCRIPTION
Check for a non-empty `TotalPax` from `LiveFeedSource` rather than just the `LiveFeedSource`
Fixes case where we have live feed data for a flight where it didn't contain any passenger numbers. Since we have nothing to compare the API data to then we should assume it's valid as we do at ports with no live feed pax nos