### PR TITLE
DRTII-1225 use feedsource name to find object

### DIFF
--- a/shared/src/main/scala/uk/gov/homeoffice/drt/ports/FeedSources.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/ports/FeedSources.scala
@@ -101,9 +101,7 @@ case object UnknownFeedSource extends FeedSource {
 object FeedSource {
   def feedSources: Set[FeedSource] = Set(ApiFeedSource, AclFeedSource, ForecastFeedSource, HistoricApiFeedSource, LiveFeedSource, LiveBaseFeedSource, ScenarioSimulationSource)
 
-  def apply(feedSource: String): Option[FeedSource] = feedSources.find(fs => fs.toString == feedSource)
-
-  def findByName(feedSource: String): Option[FeedSource] = feedSources.find(fs => fs.name == feedSource)
+  def apply(feedSource: String): Option[FeedSource] = feedSources.find(fs => fs.toString == feedSource || fs.name == feedSource)
 
   implicit val feedSourceReadWriter: ReadWriter[FeedSource] =
     readwriter[Value].bimap[FeedSource](

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/ports/FeedSourceSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/ports/FeedSourceSpec.scala
@@ -1,0 +1,27 @@
+package uk.gov.homeoffice.drt.ports
+
+import org.specs2.mutable.Specification
+
+class FeedSourceSpec extends Specification {
+
+  "ACL feedSource object is retrieved" >> {
+
+    "When 'ACL Random' is passed as text for feedSource" >> {
+      val feedSource = FeedSource("ACL Random")
+
+      feedSource === None
+    }
+
+    "When 'ACL' is passed as text for feedSource" >> {
+      val feedSource = FeedSource("ACL")
+
+      feedSource === Some(AclFeedSource)
+    }
+
+    "when 'AclFeedSource' is passed as text for feedSource" >> {
+      val feedSource = FeedSource("AclFeedSource")
+
+      feedSource === Some(AclFeedSource)
+    }
+  }
+}


### PR DESCRIPTION
To fix the historic time machine pax number need to check feedsource name 