### PR TITLE
Drtii 1206 reduce persistence storage size

### DIFF
--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/actor/RecoveryLogging.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/actor/RecoveryLogging.scala
@@ -11,10 +11,10 @@ trait RecoveryLogging {
 
   def snapshotOfferLogMessage(md: SnapshotMetadata): String = s"$prefix received SnapshotOffer from ${SDate(md.timestamp).toISOString}, sequence number ${md.sequenceNr}"
 
-  def logSnapshotOffer(md: SnapshotMetadata): Unit = log.info(snapshotOfferLogMessage(md))
+  def logSnapshotOffer(md: SnapshotMetadata): Unit = log.debug(snapshotOfferLogMessage(md))
 
   def logSnapshotOffer(md: SnapshotMetadata,
-                       additionalInfo: String): Unit = log.info(s"${snapshotOfferLogMessage(md)} - $additionalInfo")
+                       additionalInfo: String): Unit = log.debug(s"${snapshotOfferLogMessage(md)} - $additionalInfo")
 
   def logRecoveryMessage(message: String): Unit = log.info(s"$prefix - $message")
 
@@ -25,6 +25,6 @@ trait RecoveryLogging {
   def logCounters(bytes: Int, messages: Int, bytesThreshold: Int, maybeMessageThreshold: Option[Int]): Unit = {
     val megaBytes = bytes.toDouble / (1024 * 1024)
     val megaBytesThreshold = bytesThreshold.toDouble / (1024 * 1024)
-    log.info(f"$megaBytes%.2fMB persisted in $messages messages since last snapshot. Thresholds: $megaBytesThreshold%.2fMB, $maybeMessageThreshold messages")
+    log.debug(f"$megaBytes%.2fMB persisted in $messages messages since last snapshot. Thresholds: $megaBytesThreshold%.2fMB, $maybeMessageThreshold messages")
   }
 }

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/protobuf/Serializer.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/protobuf/Serializer.scala
@@ -16,7 +16,7 @@ import uk.gov.homeoffice.drt.protobuf.messages.RegisteredArrivalMessage.{Registe
 import uk.gov.homeoffice.drt.protobuf.messages.ShiftMessage.{ShiftMessage, ShiftStateSnapshotMessage, ShiftsMessage}
 import uk.gov.homeoffice.drt.protobuf.messages.StaffMovementMessages.{RemoveStaffMovementMessage, StaffMovementMessage, StaffMovementsMessage, StaffMovementsStateSnapshotMessage}
 import uk.gov.homeoffice.drt.protobuf.messages.TerminalQueuesSummary.TerminalQueuesSummaryMessage
-import uk.gov.homeoffice.drt.protobuf.messages.VoyageManifest.{ManifestLikeMessage, ManifestPassengerProfileMessage, MaybeManifestLikeMessage, VoyageManifestLatestFileNameMessage, VoyageManifestMessage, VoyageManifestStateSnapshotMessage, VoyageManifestsMessage}
+import uk.gov.homeoffice.drt.protobuf.messages.VoyageManifest._
 
 class Serializer extends SerializerWithStringManifest {
   override def identifier: Int = 9001
@@ -28,6 +28,7 @@ class Serializer extends SerializerWithStringManifest {
   final val CrunchMinutes: String = classOf[CrunchMinutesMessage].getName
   final val FlightsWithSplits: String = classOf[FlightsWithSplitsMessage].getName
   final val FlightsWithSplitsDiff: String = classOf[FlightsWithSplitsDiffMessage].getName
+  final val SplitsForArrivals: String = classOf[SplitsForArrivalsMessage].getName
   final val Shifts: String = classOf[ShiftsMessage].getName
   final val ShiftStateSnapshot: String = classOf[ShiftStateSnapshotMessage].getName
   final val Shift: String = classOf[ShiftMessage].getName
@@ -126,6 +127,7 @@ class Serializer extends SerializerWithStringManifest {
       case RemoveDay => RemoveDayMessage.parseFrom(bytes)
       case FlightsWithSplits => FlightsWithSplitsMessage.parseFrom(bytes)
       case FlightsWithSplitsDiff => FlightsWithSplitsDiffMessage.parseFrom(bytes)
+      case SplitsForArrivals => SplitsForArrivalsMessage.parseFrom(bytes)
       case CrunchRequest => CrunchRequestMessage.parseFrom(bytes)
       case CrunchRequests => CrunchRequestsMessage.parseFrom(bytes)
       case RemoveCrunchRequest => RemoveCrunchRequestMessage.parseFrom(bytes)

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/protobuf/serialisation/FlightMessageConversion.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/protobuf/serialisation/FlightMessageConversion.scala
@@ -49,10 +49,11 @@ object FlightMessageConversion {
     )
   }
 
-  def arrivalsDiffFromMessage(flightsDiffMessage: FlightsDiffMessage) = {
-    val updates = flightsDiffMessage.updates.map(flightMessageToApiFlight)
-    val removals = flightsDiffMessage.removals.map(uniqueArrivalFromMessage)
-  }
+  def arrivalsDiffFromMessage(flightsDiffMessage: FlightsDiffMessage): ArrivalsDiff =
+    ArrivalsDiff(
+      toUpdate = flightsDiffMessage.updates.map(flightMessageToApiFlight),
+      toRemove = flightsDiffMessage.removals.map(uniqueArrivalFromMessage)
+    )
 
   def uniqueArrivalsFromMessages(uniqueArrivalMessages: Seq[UniqueArrivalMessage]): Seq[UniqueArrivalLike] =
     uniqueArrivalMessages.collect {

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/protobuf/serialisation/FlightMessageConversion.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/protobuf/serialisation/FlightMessageConversion.scala
@@ -26,9 +26,9 @@ object FlightMessageConversion {
   def uniqueArrivalFromMessage(unique: UniqueArrivalMessage): UniqueArrival =
     UniqueArrival(unique.number.getOrElse(0), Terminal(unique.terminalName.getOrElse("")), unique.scheduled.getOrElse(0L), PortCode(unique.origin.getOrElse("")))
 
-  def flightWithSplitsDiffToMessage(diff: FlightsWithSplitsDiff): FlightsWithSplitsDiffMessage = {
+  def flightWithSplitsDiffToMessage(diff: FlightsWithSplitsDiff, nowMillis: Long): FlightsWithSplitsDiffMessage = {
     FlightsWithSplitsDiffMessage(
-      createdAt = Option(SDate.now().millisSinceEpoch),
+      createdAt = Option(nowMillis),
       removals = diff.arrivalsToRemove.map {
         case UniqueArrival(number, terminal, scheduled, origin) =>
           UniqueArrivalMessage(Option(number), Option(terminal.toString), Option(scheduled), Option(origin.toString))
@@ -39,11 +39,11 @@ object FlightMessageConversion {
     )
   }
 
-  def arrivalsDiffToMessage(arrivalsDiff: ArrivalsDiff): FlightsDiffMessage = {
+  def arrivalsDiffToMessage(arrivalsDiff: ArrivalsDiff, nowMillis: Long): FlightsDiffMessage = {
     val updateMessages = arrivalsDiff.toUpdate.values.map(apiFlightToFlightMessage).toSeq
     val removalMessages = arrivalsDiff.toRemove.map(a => uniqueArrivalToMessage(a)).toSeq
     FlightsDiffMessage(
-      createdAt = Option(SDate.now().millisSinceEpoch),
+      createdAt = Option(nowMillis),
       removals = removalMessages,
       updates = updateMessages
     )

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/protobuf/serialisation/FlightMessageConversion.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/protobuf/serialisation/FlightMessageConversion.scala
@@ -55,6 +55,24 @@ object FlightMessageConversion {
       toRemove = flightsDiffMessage.removals.map(uniqueArrivalFromMessage)
     )
 
+  def splitsForArrivalsToMessage(splitsForArrivals: SplitsForArrivals, nowMillis: Long): SplitsForArrivalsMessage =
+    SplitsForArrivalsMessage(
+      createdAt = Option(nowMillis),
+      splitsForArrivals = splitsForArrivals.splits.toSeq.map { case (ua, splits) =>
+        SplitsForArrivalMessage(
+          Option(uniqueArrivalToMessage(ua)),
+          splits.map(apiSplitsToMessage).toSeq
+        )
+      }
+    )
+
+  def splitsForArrivalsFromMessage(msg: SplitsForArrivalsMessage): SplitsForArrivals =
+    SplitsForArrivals(
+      msg.splitsForArrivals.map(sfa =>
+        uniqueArrivalFromMessage(sfa.getUniqueArrival) -> sfa.splits.map(splitMessageToApiSplits).toSet
+      ).toMap
+    )
+
   def uniqueArrivalsFromMessages(uniqueArrivalMessages: Seq[UniqueArrivalMessage]): Seq[UniqueArrivalLike] =
     uniqueArrivalMessages.collect {
       case UniqueArrivalMessage(Some(number), Some(terminalName), Some(scheduled), Some(origin)) =>

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/protobuf/serialisation/FlightMessageConversionSpec.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/protobuf/serialisation/FlightMessageConversionSpec.scala
@@ -155,7 +155,7 @@ class FlightMessageConversionSpec extends Specification {
         PaxNumbers
       )))), List(arrival.unique))
     "When I convert it to a protobuf message and then back to an FlightsWithSplitsDiff" >> {
-      val diffMessage = FlightMessageConversion.flightWithSplitsDiffToMessage(diff)
+      val diffMessage = FlightMessageConversion.flightWithSplitsDiffToMessage(diff, 100L)
       val restoredDiff = FlightMessageConversion.flightWithSplitsDiffFromMessage(diffMessage)
       "Then the converted FlightsWithSplitsDiff should match the original" >> {
         restoredDiff === diff

--- a/proto/src/main/protobuf/CrunchState.proto
+++ b/proto/src/main/protobuf/CrunchState.proto
@@ -57,6 +57,16 @@ message SplitMessage {
     optional string style = 3;
 }
 
+message SplitsForArrivalsMessage {
+    optional int64 createdAt = 1;
+    repeated SplitsForArrivalMessage splitsForArrivals = 2;
+}
+
+message SplitsForArrivalMessage {
+    optional UniqueArrivalMessage uniqueArrival = 1;
+    repeated SplitMessage splits = 2;
+}
+
 message SplitNationalityCountMessage {
     optional string paxNationality = 1;
     optional double count = 2;

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiff.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiff.scala
@@ -20,7 +20,7 @@ object ArrivalsDiff {
 }
 
 case class ArrivalsDiff(toUpdate: SortedMap[UniqueArrival, Arrival], toRemove: Iterable[UniqueArrival]) extends FlightUpdates {
-  def diffWith(arrivals: Map[UniqueArrival, Arrival]): ArrivalsDiff = {
+  def diff(arrivals: Map[UniqueArrival, Arrival]): ArrivalsDiff = {
     val updatedFlights = toUpdate
       .map {
         case (key, incomingArrival) =>

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiff.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiff.scala
@@ -4,11 +4,14 @@ import uk.gov.homeoffice.drt.DataUpdates.FlightUpdates
 import uk.gov.homeoffice.drt.ports.FeedSource
 import uk.gov.homeoffice.drt.ports.Terminals.Terminal
 import uk.gov.homeoffice.drt.time.{SDateLike, UtcDate}
+import upickle.default.{macroRW, _}
 
 import scala.collection.immutable.SortedMap
 
 
 object ArrivalsDiff {
+  implicit val rw: ReadWriter[ArrivalsDiff] = macroRW
+
   val empty: ArrivalsDiff = ArrivalsDiff(Seq(), Seq())
 
   def apply(toUpdate: Iterable[Arrival], toRemove: Iterable[UniqueArrival]): ArrivalsDiff = ArrivalsDiff(

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiff.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiff.scala
@@ -1,0 +1,108 @@
+package uk.gov.homeoffice.drt.arrivals
+
+import uk.gov.homeoffice.drt.DataUpdates.FlightUpdates
+import uk.gov.homeoffice.drt.ports.FeedSource
+import uk.gov.homeoffice.drt.ports.Terminals.Terminal
+import uk.gov.homeoffice.drt.time.{SDateLike, UtcDate}
+
+import scala.collection.immutable.SortedMap
+
+
+object ArrivalsDiff {
+  val empty: ArrivalsDiff = ArrivalsDiff(Seq(), Seq())
+
+  def apply(toUpdate: Iterable[Arrival], toRemove: Iterable[UniqueArrival]): ArrivalsDiff = ArrivalsDiff(
+    SortedMap[UniqueArrival, Arrival]() ++ toUpdate.map(a => (a.unique, a)), toRemove
+  )
+}
+
+case class ArrivalsDiff(toUpdate: SortedMap[UniqueArrival, Arrival], toRemove: Iterable[UniqueArrival]) extends FlightUpdates {
+  def diffWith(arrivals: Map[UniqueArrival, Arrival]): ArrivalsDiff = {
+    val updatedFlights = toUpdate
+      .map {
+        case (key, incomingArrival) =>
+          arrivals.get(key) match {
+            case Some(existingArrival) =>
+              val updatedArrival = existingArrival.update(incomingArrival)
+              if (updatedArrival.isEqualTo(existingArrival))
+                None
+              else
+                Some(updatedArrival)
+            case None =>
+              Some(incomingArrival)
+          }
+      }
+      .collect { case Some(updatedFlight) => updatedFlight }
+
+    val validRemovals = toRemove.filter(toRemove => arrivals.contains(toRemove))
+
+    ArrivalsDiff(updatedFlights, validRemovals)
+  }
+
+  def splitByScheduledUtcDate(implicit millisToSdate: Long => SDateLike): List[(UtcDate, ArrivalsDiff)] = {
+    val updatesByDate = toUpdate.values.groupBy(d => millisToSdate(d.Scheduled).toUtcDate)
+    val removalsByDate = toRemove.groupBy(d => millisToSdate(d.scheduled).toUtcDate)
+
+    val dates = updatesByDate.keys ++ removalsByDate.keys
+
+    dates
+      .map { date =>
+        val updates = updatesByDate.getOrElse(date, Seq())
+        val removals = removalsByDate.getOrElse(date, Seq())
+
+        (date, ArrivalsDiff(updates, removals))
+      }
+      .toList
+      .sortBy(_._1)
+  }
+
+  def forTerminal(terminal: Terminal): ArrivalsDiff = ArrivalsDiff(
+    toUpdate.filter { case (_, arrival) => arrival.Terminal == terminal },
+    toRemove.filter(_.terminal == terminal)
+  )
+
+  def window(from: Long, to: Long): ArrivalsDiff = ArrivalsDiff(
+    toUpdate.filter {
+      case (_, arrival) =>
+        from <= arrival.Scheduled && arrival.Scheduled <= to
+    },
+    toRemove.filter {
+      arrival =>
+        from <= arrival.scheduled && arrival.scheduled <= to
+    }
+  )
+
+  def updateMinutes(sourceOrderPreference: List[FeedSource]): Set[Long] = toUpdate.values.flatMap(_.pcpRange(sourceOrderPreference)).toSet
+
+  def applyTo(flightsWithSplits: FlightsWithSplits, nowMillis: Long, sourceOrderPreference: List[FeedSource]): (FlightsWithSplits, Set[Long]) = {
+    val updated = toUpdate.foldLeft(flightsWithSplits.flights) {
+      case (acc, (key, arrival)) =>
+        acc.get(key) match {
+          case Some(fws) =>
+            acc + (key -> fws.copy(apiFlight = arrival, lastUpdated = Option(nowMillis)))
+          case None =>
+            acc + (key -> ApiFlightWithSplits(arrival, Set(), Option(nowMillis)))
+        }
+    }
+
+    val minusRemovals: Map[UniqueArrival, ApiFlightWithSplits] = ArrivalsRemoval.removeArrivals(toRemove, updated)
+
+    val minutesFromRemovalsInExistingState: Set[Long] = toRemove
+      .flatMap { r => flightsWithSplits.flights.get(r).map(_.apiFlight.pcpRange(sourceOrderPreference)).getOrElse(List()) }
+      .toSet
+
+    val minutesFromExistingStateUpdatedFlights = toUpdate
+      .flatMap { case (unique, _) =>
+        flightsWithSplits.flights.get(unique) match {
+          case None => Set()
+          case Some(f) => f.apiFlight.pcpRange(sourceOrderPreference)
+        }
+      }.toSet
+
+    val updatedMinutesFromFlights = minutesFromRemovalsInExistingState ++
+      updateMinutes(sourceOrderPreference) ++
+      minutesFromExistingStateUpdatedFlights
+
+    (FlightsWithSplits(minusRemovals), updatedMinutesFromFlights)
+  }
+}

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/FlightsWithSplitsDiff.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/FlightsWithSplitsDiff.scala
@@ -29,6 +29,14 @@ class ArrivalsRestorer[A <: WithUnique[UniqueArrival] with Updatable[A]] {
     arrivals = arrivals + ((update.unique, updated))
   }
 
+  def applyUpdates[B](updates: Map[UniqueArrival, B], update: (A, B) => A): Unit =
+    updates.foreach {
+      case (key, incoming) =>
+        arrivals.get(key).foreach {
+          a => arrivals = arrivals + ((key, update(a, incoming)))
+        }
+    }
+
   def remove(removals: Iterable[UniqueArrivalLike]): Unit =
     arrivals = ArrivalsRemoval.removeArrivals(removals, arrivals)
 

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/FlightsWithSplitsDiff.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/FlightsWithSplitsDiff.scala
@@ -29,11 +29,11 @@ class ArrivalsRestorer[A <: WithUnique[UniqueArrival] with Updatable[A]] {
     arrivals = arrivals + ((update.unique, updated))
   }
 
-  def applyUpdates[B](updates: Map[UniqueArrival, B], update: (A, B) => A): Unit =
+  def applyUpdates[B](updates: Map[UniqueArrival, B], update: (Option[A], B) => Option[A]): Unit =
     updates.foreach {
       case (key, incoming) =>
-        arrivals.get(key).foreach {
-          a => arrivals = arrivals + ((key, update(a, incoming)))
+        update(arrivals.get(key), incoming).foreach { updated =>
+          arrivals = arrivals + ((key, updated))
         }
     }
 

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
@@ -42,18 +42,18 @@ object SplitsForArrivals {
 
 case class SplitsForArrivals(splits: Map[UniqueArrival, Set[Splits]]) extends FlightUpdates {
 
-  def diff(other: Map[UniqueArrival, Set[Splits]]): SplitsForArrivals = {
+  def diff(oldOnes: Map[UniqueArrival, Set[Splits]]): SplitsForArrivals = {
     val updatedSplits = splits
-      .map {
-        case (key, ourSplits) =>
-          other.get(key)
-            .map(existing => ourSplits.diff(existing))
-            .collect {
-              case ourNewSplits if ourNewSplits.nonEmpty =>
-                (key, ourNewSplits)
-            }
+      .map { case (ua, split) =>
+        val oldSplits = oldOnes.getOrElse(ua, Set())
+        split.diff(oldSplits) match {
+          case empty if empty.isEmpty => None
+          case newSplits => Option((ua, newSplits))
+        }
       }
-      .collect { case Some(splits) => splits }
+      .collect {
+        case Some(updates) => updates
+      }
       .toMap
 
     SplitsForArrivals(updatedSplits)

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
@@ -1,0 +1,46 @@
+package uk.gov.homeoffice.drt.arrivals
+
+import uk.gov.homeoffice.drt.DataUpdates.FlightUpdates
+import uk.gov.homeoffice.drt.ports.ApiFeedSource
+import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages
+
+
+object SplitsForArrivals {
+  val empty: SplitsForArrivals = SplitsForArrivals(Map())
+}
+
+case class SplitsForArrivals(splits: Map[UniqueArrival, Set[Splits]]) extends FlightUpdates {
+  def diff(flights: FlightsWithSplits, nowMillis: Long): FlightsWithSplitsDiff = {
+    val updatedFlights = splits
+      .map {
+        case (key, newSplits) =>
+          flights.flights.get(key)
+            .map(fws => (fws, newSplits.diff(fws.splits)))
+            .collect {
+              case (fws, updatedSplits) if updatedSplits.nonEmpty =>
+                val updatedSources = updatedSplits.map(_.source)
+                val mergedSplits = fws.splits.filterNot(s => updatedSources.contains(s.source)) ++ updatedSplits
+                val updatedArrival = mergedSplits.find(_.source == ApiSplitsWithHistoricalEGateAndFTPercentages) match {
+                  case None =>
+                    fws.apiFlight
+                  case Some(liveSplit) =>
+                    val totalPax: Int = Math.round(liveSplit.totalPax)
+                    val transPax: Int = Math.round(liveSplit.totalPax - liveSplit.totalExcludingTransferPax).toInt
+                    val sources = fws.apiFlight.FeedSources + ApiFeedSource
+                    val totalPaxSources = fws.apiFlight.PassengerSources.updated(ApiFeedSource, Passengers(Some(totalPax), Option(transPax)))
+                    fws.apiFlight.copy(
+                      FeedSources = sources,
+                      PassengerSources = totalPaxSources
+                    )
+                }
+
+                fws.copy(apiFlight = updatedArrival, splits = mergedSplits, lastUpdated = Option(nowMillis))
+            }
+      }
+      .collect { case Some(flight) => flight }
+
+    FlightsWithSplitsDiff(updatedFlights, List())
+  }
+
+  def ++(tuple: (UniqueArrival, Set[Splits])): Map[UniqueArrival, Set[Splits]] = splits + tuple
+}

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
@@ -4,9 +4,12 @@ import uk.gov.homeoffice.drt.DataUpdates.FlightUpdates
 import uk.gov.homeoffice.drt.arrivals.SplitsForArrivals.updateFlightWithSplits
 import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages
 import uk.gov.homeoffice.drt.ports.{ApiFeedSource, FeedSource}
+import upickle.default.{macroRW, _}
 
 
 object SplitsForArrivals {
+  implicit val rw: ReadWriter[SplitsForArrivals] = macroRW
+
   val empty: SplitsForArrivals = SplitsForArrivals(Map())
 
   def updateSplits(existing: Set[Splits], incoming: Set[Splits]): Set[Splits] =

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
@@ -14,20 +14,14 @@ case class SplitsForArrivals(splits: Map[UniqueArrival, Set[Splits]]) extends Fl
     (existing.map(s => (s.source, s)).toMap ++ incoming.map(s => (s.source, s)).toMap).values.toSet
 
   def diff(other: Map[UniqueArrival, Set[Splits]]): SplitsForArrivals = {
-    val updatedSplits = other
+    val updatedSplits = splits
       .map {
-        case (key, incoming) =>
-          println(s"looking for $key to update splits. keys: ${splits.keys.map(_.toString).mkString(", ")}")
+        case (key, ourSplits) =>
           other.get(key)
-            .map { existing =>
-              println(s"found $key to update splits. existing: ${existing.map(_.toString).mkString(", ")} incoming: ${incoming.map(_.toString).mkString(", ")}")
-              val newIncoming = incoming.diff(existing)
-              println(s"new incoming: ${newIncoming.map(_.toString).mkString(", ")}")
-              (existing, newIncoming)
-            }
+            .map(existing => ourSplits.diff(existing))
             .collect {
-              case (existing, incoming) if incoming.nonEmpty =>
-                (key, updateSplits(existing, incoming))
+              case ourNewSplits if ourNewSplits.nonEmpty =>
+                (key, ourNewSplits)
             }
       }
       .collect { case Some(splits) => splits }

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
@@ -1,17 +1,43 @@
 package uk.gov.homeoffice.drt.arrivals
 
 import uk.gov.homeoffice.drt.DataUpdates.FlightUpdates
-import uk.gov.homeoffice.drt.ports.FeedSource
+import uk.gov.homeoffice.drt.arrivals.SplitsForArrivals.updateFlightWithSplits
+import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages
+import uk.gov.homeoffice.drt.ports.{ApiFeedSource, FeedSource}
 
 
 object SplitsForArrivals {
   val empty: SplitsForArrivals = SplitsForArrivals(Map())
+
+  def updateSplits(existing: Set[Splits], incoming: Set[Splits]): Set[Splits] =
+    (existing.map(s => (s.source, s)).toMap ++ incoming.map(s => (s.source, s)).toMap).values.toSet
+
+  def updateFlightWithSplits(flightWithSplits: ApiFlightWithSplits, splits: Set[Splits], nowMillis: Long): ApiFlightWithSplits = {
+    val updatedArrival = splits.find(_.source == ApiSplitsWithHistoricalEGateAndFTPercentages) match {
+      case None =>
+        flightWithSplits.apiFlight
+      case Some(liveSplit) =>
+        val totalPax: Int = Math.round(liveSplit.totalPax)
+        val transPax: Int = Math.round(liveSplit.totalPax - liveSplit.totalExcludingTransferPax).toInt
+        val sources = flightWithSplits.apiFlight.FeedSources + ApiFeedSource
+        val totalPaxSources = flightWithSplits.apiFlight.PassengerSources.updated(ApiFeedSource, Passengers(Some(totalPax), Option(transPax)))
+        flightWithSplits.apiFlight.copy(
+          FeedSources = sources,
+          PassengerSources = totalPaxSources
+        )
+    }
+    val updatedSplits = updateSplits(flightWithSplits.splits, splits)
+    val updatedFlightWithSplits = flightWithSplits.copy(
+      apiFlight = updatedArrival,
+      splits = updatedSplits,
+      lastUpdated = Option(nowMillis),
+    )
+    updatedFlightWithSplits
+  }
+
 }
 
 case class SplitsForArrivals(splits: Map[UniqueArrival, Set[Splits]]) extends FlightUpdates {
-
-  private def updateSplits(existing: Set[Splits], incoming: Set[Splits]): Set[Splits] =
-    (existing.map(s => (s.source, s)).toMap ++ incoming.map(s => (s.source, s)).toMap).values.toSet
 
   def diff(other: Map[UniqueArrival, Set[Splits]]): SplitsForArrivals = {
     val updatedSplits = splits
@@ -39,17 +65,16 @@ case class SplitsForArrivals(splits: Map[UniqueArrival, Set[Splits]]) extends Fl
     }.toSet
     val updatedFlights = splits.foldLeft(flightsWithSplits.flights) {
       case (acc, (key, incoming)) =>
-        println(s"looking for $key to update splits. keys: ${acc.keys.map(_.toString).mkString(", ")}")
         acc.get(key) match {
           case Some(flightWithSplits) =>
-            val updatedSplits = updateSplits(flightWithSplits.splits, incoming)
-            val updatedFlightWithSplits = flightWithSplits.copy(splits = updatedSplits, lastUpdated = Option(nowMillis))
+            val updatedFlightWithSplits = updateFlightWithSplits(flightWithSplits, incoming, nowMillis)
             acc + (key -> updatedFlightWithSplits)
           case None => acc
         }
     }
     (FlightsWithSplits(updatedFlights), minutesFromUpdates)
   }
+
 
   def ++(tuple: (UniqueArrival, Set[Splits])): Map[UniqueArrival, Set[Splits]] = splits + tuple
 }

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiffSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiffSpec.scala
@@ -1,0 +1,63 @@
+package uk.gov.homeoffice.drt.arrivals
+
+import org.specs2.mutable.Specification
+import uk.gov.homeoffice.drt.arrivals.SplitStyle.PaxNumbers
+import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.Historical
+
+class ArrivalsDiffSpec extends Specification {
+  val now: Long = 10L
+
+  "When I apply ArrivalsDiff to FlightsWithSplits" >> {
+    "Given no new arrivals and" >> {
+      val arrivalsDiff = ArrivalsDiff(Seq(), Seq())
+
+      "No existing flights" >> {
+        "Then I should get an empty FlightsWithSplits" >> {
+          val updated = arrivalsDiff.diffWith(Map())
+          updated === FlightsWithSplitsDiff.empty
+        }
+      }
+
+      "One existing flight" >> {
+        val arrival = ArrivalGenerator.arrival(iata = "BA0001")
+        val flights = Map(arrival.unique -> arrival)
+
+        "Then I should get an empty FlightsWithSplits" >> {
+          val updated = arrivalsDiff.diffWith(flights)
+          updated === FlightsWithSplitsDiff.empty
+        }
+      }
+    }
+
+    "Given one new arrival and" >> {
+      val arrival = ArrivalGenerator.arrival(iata = "BA0001", status = ArrivalStatus("new status"))
+      val arrivalsDiff = ArrivalsDiff(Seq(arrival), Seq())
+
+      "No existing flights" >> {
+        "Then I should get a FlightsWithSplits containing the new arrival" >> {
+          val updated = arrivalsDiff.diffWith(Map())
+          updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival, Set(), Option(now))), Seq())
+        }
+      }
+
+      "One existing flight with splits that matches and has the same arrival" >> {
+        val flights = Map(arrival.unique -> arrival)
+
+        "Then I should get an empty FlightsWithSplits" >> {
+          val updated = arrivalsDiff.diffWith(flights)
+          updated === FlightsWithSplitsDiff.empty
+        }
+      }
+
+      "One existing flight with splits that matches and has an older arrival" >> {
+        val olderArrival = arrival.copy(Status = ArrivalStatus("old status"))
+        val flights = Map(olderArrival.unique -> olderArrival)
+
+        "Then I should get a FlightsWithSplits with the updated arrival and existing splits" >> {
+          val updated = arrivalsDiff.diffWith(flights)
+          updated === ArrivalsDiff(Seq(arrival), Seq())
+        }
+      }
+    }
+  }
+}

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiffSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiffSpec.scala
@@ -11,7 +11,7 @@ class ArrivalsDiffSpec extends Specification {
 
       "No existing flights" >> {
         "Then I should get an empty FlightsWithSplits" >> {
-          val updated = arrivalsDiff.diffWith(Map())
+          val updated = arrivalsDiff.diff(Map())
           updated === ArrivalsDiff.empty
         }
       }
@@ -21,7 +21,7 @@ class ArrivalsDiffSpec extends Specification {
         val flights = Map(arrival.unique -> arrival)
 
         "Then I should get an empty FlightsWithSplits" >> {
-          val updated = arrivalsDiff.diffWith(flights)
+          val updated = arrivalsDiff.diff(flights)
           updated === ArrivalsDiff.empty
         }
       }
@@ -33,7 +33,7 @@ class ArrivalsDiffSpec extends Specification {
 
       "No existing flights" >> {
         "Then I should get a FlightsWithSplits containing the new arrival" >> {
-          val updated = arrivalsDiff.diffWith(Map())
+          val updated = arrivalsDiff.diff(Map())
           updated === ArrivalsDiff(Seq(arrival), Seq())
         }
       }
@@ -42,7 +42,7 @@ class ArrivalsDiffSpec extends Specification {
         val flights = Map(arrival.unique -> arrival)
 
         "Then I should get an empty FlightsWithSplits" >> {
-          val updated = arrivalsDiff.diffWith(flights)
+          val updated = arrivalsDiff.diff(flights)
           updated === ArrivalsDiff.empty
         }
       }
@@ -52,7 +52,7 @@ class ArrivalsDiffSpec extends Specification {
         val flights = Map(olderArrival.unique -> olderArrival)
 
         "Then I should get a FlightsWithSplits with the updated arrival and existing splits" >> {
-          val updated = arrivalsDiff.diffWith(flights)
+          val updated = arrivalsDiff.diff(flights)
           updated === ArrivalsDiff(Seq(arrival), Seq())
         }
       }

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiffSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiffSpec.scala
@@ -1,8 +1,6 @@
 package uk.gov.homeoffice.drt.arrivals
 
 import org.specs2.mutable.Specification
-import uk.gov.homeoffice.drt.arrivals.SplitStyle.PaxNumbers
-import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.Historical
 
 class ArrivalsDiffSpec extends Specification {
   val now: Long = 10L

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiffSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiffSpec.scala
@@ -12,7 +12,7 @@ class ArrivalsDiffSpec extends Specification {
       "No existing flights" >> {
         "Then I should get an empty FlightsWithSplits" >> {
           val updated = arrivalsDiff.diffWith(Map())
-          updated === FlightsWithSplitsDiff.empty
+          updated === ArrivalsDiff.empty
         }
       }
 
@@ -22,7 +22,7 @@ class ArrivalsDiffSpec extends Specification {
 
         "Then I should get an empty FlightsWithSplits" >> {
           val updated = arrivalsDiff.diffWith(flights)
-          updated === FlightsWithSplitsDiff.empty
+          updated === ArrivalsDiff.empty
         }
       }
     }
@@ -34,7 +34,7 @@ class ArrivalsDiffSpec extends Specification {
       "No existing flights" >> {
         "Then I should get a FlightsWithSplits containing the new arrival" >> {
           val updated = arrivalsDiff.diffWith(Map())
-          updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival, Set(), Option(now))), Seq())
+          updated === ArrivalsDiff(Seq(arrival), Seq())
         }
       }
 
@@ -43,7 +43,7 @@ class ArrivalsDiffSpec extends Specification {
 
         "Then I should get an empty FlightsWithSplits" >> {
           val updated = arrivalsDiff.diffWith(flights)
-          updated === FlightsWithSplitsDiff.empty
+          updated === ArrivalsDiff.empty
         }
       }
 

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivalsSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivalsSpec.scala
@@ -13,74 +13,54 @@ class SplitsForArrivalsSpec extends Specification {
   val now: Long = 10L
   val uniqueArrival: UniqueArrival = UniqueArrival(1, T1, 0L, PortCode("JFK"))
 
-  "When I apply SplitsForArrivals to FlightsWithSplits" >> {
-    "Given one new split and no arrivals" >> {
-      "Then I should get an empty FlightsWithSplits" >> {
+  "When I diff SplitsForArrivals with a FlightsWithSplits" >> {
+    "Given one new split and no existing ones" >> {
+      "Then I should get a SplitsForArrivals containing the new split" >> {
         val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(Splits(Set(), Historical, None, PaxNumbers))))
-        val flights = FlightsWithSplits(Seq())
 
-        val updated = splitsForArrivals.diff(flights, now)
+        val diff = splitsForArrivals.diff(Map())
 
-        updated === FlightsWithSplitsDiff.empty
+        diff === splitsForArrivals
       }
     }
 
-    "Given one new split and one matching arrival with no existing splits" >> {
-      "Then I should get a FlightsWithSplits containing the matching arrival with the new split" >> {
-        val newSplits = Splits(Set(), Historical, None, PaxNumbers)
-        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(newSplits)))
-        val arrival = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
-        val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival, Set())))
+    "Given one new split and one existing split with the same values as the new one" >> {
+      "Then I should get an empty diff" >> {
+        val existingSplits = Set(Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers))
+        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> existingSplits))
 
-        val updated = splitsForArrivals.diff(flights, now)
+        val diff = splitsForArrivals.diff(Map(uniqueArrival -> existingSplits))
 
-        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival, Set(newSplits), Option(now))), Seq())
+        diff === SplitsForArrivals.empty
       }
     }
 
-    "Given one new split and one matching arrival with an existing split with the same values as the new one" >> {
-      "Then I should get an empty FlightsWithSplits" >> {
-        val existingSplits = Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers)
-        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(existingSplits)))
-        val arrival = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
-        val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival, Set(existingSplits))))
+    "Given one new split and one existing split of the same source but new numbers" >> {
+      "Then I should get a SplitsForArrivals containing updated split" >> {
+        val existingSplits = Set(Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers))
+        val newSplits = Set(Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), Historical, None, PaxNumbers))
+        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> newSplits))
 
-        val updated = splitsForArrivals.diff(flights, now)
+        val diff = splitsForArrivals.diff(Map(uniqueArrival -> existingSplits))
 
-        updated === FlightsWithSplitsDiff.empty
+        diff === SplitsForArrivals(Map(uniqueArrival -> newSplits))
       }
     }
 
-    "Given one new split and one matching arrival with an existing split of the same source" >> {
-      "Then I should get a FlightsWithSplits containing the matching arrival updated with the new split" >> {
-        val existingSplits = Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers)
-        val newSplits = Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), Historical, None, PaxNumbers)
-        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(newSplits)))
-        val arrival = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
-        val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival, Set(existingSplits))))
+    "Given one new split and one existing split from a different source" >> {
+      "Then I should get a SplitsForArrivals containing just the new split" >> {
+        val existingSplits = Set(Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers))
+        val newSplits = Set(Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), ApiSplitsWithHistoricalEGateAndFTPercentages, None, PaxNumbers))
+        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> newSplits))
 
-        val updated = splitsForArrivals.diff(flights, now)
+        val diff = splitsForArrivals.diff(Map(uniqueArrival -> existingSplits))
 
-        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival, Set(newSplits), Option(now))), Seq())
+        diff === SplitsForArrivals(Map(uniqueArrival -> newSplits))
       }
     }
+  }
 
-    "Given one new split and one matching arrival with an existing split from a different source" >> {
-      "Then I should get a FlightsWithSplits containing the matching arrival with both sets of splits" >> {
-        val existingSplits = Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers)
-        val newSplits = Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), ApiSplitsWithHistoricalEGateAndFTPercentages, None, PaxNumbers)
-        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(newSplits)))
-        val arrival = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
-        val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival, Set(existingSplits))))
-
-        val updated = splitsForArrivals.diff(flights, now)
-
-        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival.copy(FeedSources = Set(ApiFeedSource),
-          PassengerSources = Map(ApiFeedSource -> Passengers(Option(1), Some(0))),
-        ), Set(newSplits, existingSplits), Option(now))), Seq())
-      }
-    }
-
+  "When I apply SplitsForArrivals to FlightsWithSplits" >> {
     "Given one new split and one matching arrival with 2 existing splits, one from the same source" >> {
       "Then I should get a FlightsWithSplits containing the matching arrival with the newly updated split along with the other pre-existing split" >> {
         val existingSplits1 = Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers)
@@ -90,29 +70,41 @@ class SplitsForArrivalsSpec extends Specification {
         val arrival = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
         val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival, Set(existingSplits1, existingSplits2))))
 
-        val updated = splitsForArrivals.diff(flights, now)
+        val updated = splitsForArrivals.applyTo(flights, now, List())._1
 
-        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival.copy(FeedSources = Set(ApiFeedSource),
+        updated === FlightsWithSplits(Seq(ApiFlightWithSplits(arrival.copy(FeedSources = Set(ApiFeedSource),
           PassengerSources = Map(ApiFeedSource -> Passengers(Option(1), Some(0)))),
-          Set(newSplits, existingSplits1), Option(now))), Seq())
+          Set(newSplits, existingSplits1), Option(now))))
       }
     }
 
-    "Given 2 splits and two arrivals, with only one matching and with an existing split" >> {
-      "Then I should get a FlightsWithSplits containing the matching arrival updated with the correct new split" >> {
-        val uniqueArrival2 = UniqueArrival(200, T1, 0L, PortCode("JFK"))
+    "Given 2 splits and two arrivals, one with a new source and one with the same source" >> {
+      "Then I should get a FlightsWithSplits containing the arrivals updated with the correct new splits" >> {
+        val arrival1 = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
+        val arrival2 = ArrivalGenerator.arrival(iata = "FR1234", terminal = T1, origin = PortCode("JFK"))
         val existingSplits1 = Splits(Set(ApiPaxTypeAndQueueCount(VisaNational, NonEeaDesk, 1, None, None)), Historical, None, PaxNumbers)
         val existingSplits2 = Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers)
         val newSplits1 = Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), Historical, None, PaxNumbers)
-        val newSplits2 = Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), Historical, None, PaxNumbers)
-        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(newSplits1), uniqueArrival2 -> Set(newSplits2)))
-        val arrival1 = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
-        val arrival2 = ArrivalGenerator.arrival(iata = "FR1234", terminal = T1, origin = PortCode("JFK"))
-        val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival1, Set(existingSplits1)), ApiFlightWithSplits(arrival2, Set(existingSplits2))))
+        val newSplits2 = Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), ApiSplitsWithHistoricalEGateAndFTPercentages, None, PaxNumbers)
 
-        val updated = splitsForArrivals.diff(flights, now)
+        val splitsForArrivals = SplitsForArrivals(Map(arrival1.unique -> Set(newSplits1), arrival2.unique -> Set(newSplits2)))
 
-        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival1, Set(newSplits1), Option(now))), Seq())
+        val flights = FlightsWithSplits(Seq(
+          ApiFlightWithSplits(arrival1, Set(existingSplits1)),
+          ApiFlightWithSplits(arrival2, Set(existingSplits2))
+        ))
+
+        val updated = splitsForArrivals.applyTo(flights, now, List())._1
+
+        val arrival2WithApiSources = arrival2.copy(
+          FeedSources = arrival2.FeedSources + ApiFeedSource,
+          PassengerSources = arrival2.PassengerSources + (ApiFeedSource -> Passengers(Option(1), Some(0)))
+        )
+
+        updated === FlightsWithSplits(Seq(
+          ApiFlightWithSplits(arrival1, Set(newSplits1), Option(now)),
+          ApiFlightWithSplits(arrival2WithApiSources, Set(existingSplits2, newSplits2), Option(now)),
+        ))
       }
     }
   }

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivalsSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivalsSpec.scala
@@ -1,0 +1,119 @@
+package uk.gov.homeoffice.drt.arrivals
+
+import org.specs2.mutable.Specification
+import uk.gov.homeoffice.drt.arrivals.SplitStyle.PaxNumbers
+import uk.gov.homeoffice.drt.ports.PaxTypes._
+import uk.gov.homeoffice.drt.ports.Queues.{EGate, EeaDesk, NonEeaDesk}
+import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.{ApiSplitsWithHistoricalEGateAndFTPercentages, Historical}
+import uk.gov.homeoffice.drt.ports.Terminals.T1
+import uk.gov.homeoffice.drt.ports._
+
+class SplitsForArrivalsSpec extends Specification {
+
+  val now: Long = 10L
+  val uniqueArrival: UniqueArrival = UniqueArrival(1, T1, 0L, PortCode("JFK"))
+
+  "When I apply SplitsForArrivals to FlightsWithSplits" >> {
+    "Given one new split and no arrivals" >> {
+      "Then I should get an empty FlightsWithSplits" >> {
+        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(Splits(Set(), Historical, None, PaxNumbers))))
+        val flights = FlightsWithSplits(Seq())
+
+        val updated = splitsForArrivals.diff(flights, now)
+
+        updated === FlightsWithSplitsDiff.empty
+      }
+    }
+
+    "Given one new split and one matching arrival with no existing splits" >> {
+      "Then I should get a FlightsWithSplits containing the matching arrival with the new split" >> {
+        val newSplits = Splits(Set(), Historical, None, PaxNumbers)
+        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(newSplits)))
+        val arrival = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
+        val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival, Set())))
+
+        val updated = splitsForArrivals.diff(flights, now)
+
+        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival, Set(newSplits), Option(now))), Seq())
+      }
+    }
+
+    "Given one new split and one matching arrival with an existing split with the same values as the new one" >> {
+      "Then I should get an empty FlightsWithSplits" >> {
+        val existingSplits = Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers)
+        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(existingSplits)))
+        val arrival = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
+        val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival, Set(existingSplits))))
+
+        val updated = splitsForArrivals.diff(flights, now)
+
+        updated === FlightsWithSplitsDiff.empty
+      }
+    }
+
+    "Given one new split and one matching arrival with an existing split of the same source" >> {
+      "Then I should get a FlightsWithSplits containing the matching arrival updated with the new split" >> {
+        val existingSplits = Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers)
+        val newSplits = Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), Historical, None, PaxNumbers)
+        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(newSplits)))
+        val arrival = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
+        val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival, Set(existingSplits))))
+
+        val updated = splitsForArrivals.diff(flights, now)
+
+        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival, Set(newSplits), Option(now))), Seq())
+      }
+    }
+
+    "Given one new split and one matching arrival with an existing split from a different source" >> {
+      "Then I should get a FlightsWithSplits containing the matching arrival with both sets of splits" >> {
+        val existingSplits = Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers)
+        val newSplits = Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), ApiSplitsWithHistoricalEGateAndFTPercentages, None, PaxNumbers)
+        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(newSplits)))
+        val arrival = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
+        val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival, Set(existingSplits))))
+
+        val updated = splitsForArrivals.diff(flights, now)
+
+        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival.copy(FeedSources = Set(ApiFeedSource),
+          PassengerSources = Map(ApiFeedSource -> Passengers(Option(1), Some(0))),
+        ), Set(newSplits, existingSplits), Option(now))), Seq())
+      }
+    }
+
+    "Given one new split and one matching arrival with 2 existing splits, one from the same source" >> {
+      "Then I should get a FlightsWithSplits containing the matching arrival with the newly updated split along with the other pre-existing split" >> {
+        val existingSplits1 = Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers)
+        val existingSplits2 = Splits(Set(ApiPaxTypeAndQueueCount(VisaNational, EGate, 1, None, None)), ApiSplitsWithHistoricalEGateAndFTPercentages, None, PaxNumbers)
+        val newSplits = Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), ApiSplitsWithHistoricalEGateAndFTPercentages, None, PaxNumbers)
+        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(newSplits)))
+        val arrival = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
+        val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival, Set(existingSplits1, existingSplits2))))
+
+        val updated = splitsForArrivals.diff(flights, now)
+
+        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival.copy(FeedSources = Set(ApiFeedSource),
+          PassengerSources = Map(ApiFeedSource -> Passengers(Option(1), Some(0)))),
+          Set(newSplits, existingSplits1), Option(now))), Seq())
+      }
+    }
+
+    "Given 2 splits and two arrivals, with only one matching and with an existing split" >> {
+      "Then I should get a FlightsWithSplits containing the matching arrival updated with the correct new split" >> {
+        val uniqueArrival2 = UniqueArrival(200, T1, 0L, PortCode("JFK"))
+        val existingSplits1 = Splits(Set(ApiPaxTypeAndQueueCount(VisaNational, NonEeaDesk, 1, None, None)), Historical, None, PaxNumbers)
+        val existingSplits2 = Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers)
+        val newSplits1 = Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), Historical, None, PaxNumbers)
+        val newSplits2 = Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), Historical, None, PaxNumbers)
+        val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(newSplits1), uniqueArrival2 -> Set(newSplits2)))
+        val arrival1 = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
+        val arrival2 = ArrivalGenerator.arrival(iata = "FR1234", terminal = T1, origin = PortCode("JFK"))
+        val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival1, Set(existingSplits1)), ApiFlightWithSplits(arrival2, Set(existingSplits2))))
+
+        val updated = splitsForArrivals.diff(flights, now)
+
+        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival1, Set(newSplits1), Option(now))), Seq())
+      }
+    }
+  }
+}


### PR DESCRIPTION
Move `ArrivalsDiff` & `SplitsForArrivals` here for wider access
Add `SplitsForArrivalsMessage` to persist smaller chunks of updates
Refactor to detect changes and apply changes more efficiently