### PR TITLE
Drtii 1279 pax nos in planning dont match arrivals export

### DIFF
--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ApiArrivalsWithSplits.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ApiArrivalsWithSplits.scala
@@ -27,12 +27,6 @@ case class ApiFlightWithSplits(apiFlight: Arrival, splits: Set[Splits], lastUpda
       PaxSource(ApiFeedSource, Passengers(Option(splits.totalPax), Option(splits.transPax)))
   }
 
-  def bestPaxSource(sourceOrderPreference: List[FeedSource]): PaxSource =
-    paxFromApi match {
-      case Some(totalPaxSource) if hasValidApi => totalPaxSource
-      case _ => apiFlight.bestPaxEstimate(sourceOrderPreference)
-    }
-
   def equals(candidate: ApiFlightWithSplits): Boolean =
     this.copy(lastUpdated = None) == candidate.copy(lastUpdated = None)
 

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/Arrival.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/Arrival.scala
@@ -155,7 +155,6 @@ case class Arrival(Operator: Option[Operator],
       .find(source => PassengerSources.get(source).exists(_.actual.isDefined))
       .flatMap(source => PassengerSources.get(source).map(PaxSource(source, _)))
       .getOrElse(PaxSource(UnknownFeedSource, Passengers(None, None)))
-
   }
 
   def bestPcpPaxEstimate(sourceOrderPreference: List[FeedSource]): Option[Int] = bestPaxEstimate(sourceOrderPreference).getPcpPax
@@ -237,7 +236,7 @@ object Arrival {
   }
 
   def isInRange(rangeStart: Long, rangeEnd: Long)(needle: Long): Boolean =
-    rangeStart < needle && needle < rangeEnd
+    rangeStart <= needle && needle <= rangeEnd
 
   def isRelevantToPeriod(rangeStart: SDateLike, rangeEnd: SDateLike, sourceOrderPreference: List[FeedSource])(arrival: Arrival): Boolean = {
     val rangeCheck: Long => Boolean = isInRange(rangeStart.millisSinceEpoch, rangeEnd.millisSinceEpoch)

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/splits/ApiSplitsToSplitRatio.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/splits/ApiSplitsToSplitRatio.scala
@@ -2,7 +2,7 @@ package uk.gov.homeoffice.drt.splits
 
 import uk.gov.homeoffice.drt.arrivals.{ApiFlightWithSplits, SplitStyle, Splits}
 import uk.gov.homeoffice.drt.ports.Queues.Queue
-import uk.gov.homeoffice.drt.ports.{AclFeedSource, ApiFeedSource, ApiPaxTypeAndQueueCount, FeedSource, ForecastFeedSource, HistoricApiFeedSource, LiveFeedSource, MlFeedSource, PaxTypeAndQueue, Queues, ScenarioSimulationSource}
+import uk.gov.homeoffice.drt.ports.{ApiPaxTypeAndQueueCount, FeedSource, PaxTypeAndQueue, Queues}
 
 object ApiSplitsToSplitRatio {
 
@@ -23,7 +23,7 @@ object ApiSplitsToSplitRatio {
 
   def flightPaxPerQueueUsingSplitsAsRatio(splits: Splits, fws: ApiFlightWithSplits, sourceOrderPreference: List[FeedSource]): Map[Queue, Int] =
     queueTotals(
-      applyPaxSplitsToFlightPax(splits, fws.bestPaxSource(sourceOrderPreference).passengers.getPcpPax.getOrElse(0))
+      applyPaxSplitsToFlightPax(splits, fws.apiFlight.bestPcpPaxEstimate(sourceOrderPreference).getOrElse(0))
         .splits
         .map(ptqc => PaxTypeAndQueue(ptqc.passengerType, ptqc.queueType) -> ptqc.paxCount.toInt)
         .toMap

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ApiFlightWithSplitsSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ApiFlightWithSplitsSpec.scala
@@ -122,7 +122,7 @@ class ApiFlightWithSplitsSpec extends Specification {
       "and api splits has pax number and hasValidApi is true" in {
         val flightWithSplits = flightWithPaxAndApiSplits(100, 0, Set(LiveFeedSource), Map(LiveFeedSource -> Passengers(None,Option(0))), scheduledAfterPaxSources)
         flightWithSplits.hasValidApi mustEqual true
-        flightWithSplits.bestPaxSource(sourceOrderPreference).getPcpPax must beSome(100)
+        flightWithSplits.apiFlight.bestPcpPaxEstimate(sourceOrderPreference) must beSome(100)
         val paxPerQueue: Option[Map[Queues.Queue, Int]] = ApiSplitsToSplitRatio.paxPerQueueUsingBestSplitsAsRatio(flightWithSplits, sourceOrderPreference)
         paxPerQueue must beSome(collection.Map(Queues.NonEeaDesk -> 100))
       }
@@ -132,8 +132,8 @@ class ApiFlightWithSplitsSpec extends Specification {
       "and api splits has pax number and hasValidApi is false" in {
         val flightWithSplits = flightWithPaxAndApiSplits(100, 0, Set(LiveFeedSource), Map(LiveFeedSource -> Passengers(Option(95), Option(0))), scheduledAfterPaxSources)
         flightWithSplits.hasValidApi mustEqual false
-        flightWithSplits.bestPaxSource(sourceOrderPreference).getPcpPax must beSome(95)
-        flightWithSplits.bestPaxSource(sourceOrderPreference).feedSource === LiveFeedSource
+        flightWithSplits.apiFlight.bestPcpPaxEstimate(sourceOrderPreference) must beSome(95)
+        flightWithSplits.apiFlight.bestPaxEstimate(sourceOrderPreference).feedSource === LiveFeedSource
         val paxPerQueue: Option[Map[Queues.Queue, Int]] = ApiSplitsToSplitRatio.paxPerQueueUsingBestSplitsAsRatio(flightWithSplits, sourceOrderPreference)
         paxPerQueue must beNone
       }
@@ -141,32 +141,32 @@ class ApiFlightWithSplitsSpec extends Specification {
 
     "give a pax count from splits when it has API splits" in {
       val flightWithSplits = flightWithPaxAndApiSplits( 45, 0, Set(), Map(), scheduledAfterPaxSources)
-      flightWithSplits.bestPaxSource(sourceOrderPreference).passengers.actual mustEqual Option(45)
+      flightWithSplits.apiFlight.bestPaxEstimate(sourceOrderPreference).passengers.actual mustEqual Option(45)
     }
 
     "give a pax count from splits when it has API splits which does not include transfer pax" in {
       val flightWithSplits = flightWithPaxAndApiSplits(45, 20, Set(), Map(), scheduledAfterPaxSources)
-      flightWithSplits.bestPaxSource(sourceOrderPreference).passengers.getPcpPax mustEqual Option(45)
+      flightWithSplits.apiFlight.bestPaxEstimate(sourceOrderPreference).passengers.getPcpPax mustEqual Option(45)
     }
 
     "give a pax count from splits when it has API splits even when it is outside the trusted threshold" in {
       val flightWithSplits = flightWithPaxAndApiSplits( 150, 0, Set(LiveFeedSource), Map(), scheduledAfterPaxSources)
-      flightWithSplits.bestPaxSource(sourceOrderPreference).passengers.actual mustEqual Option(150)
+      flightWithSplits.apiFlight.bestPaxEstimate(sourceOrderPreference).passengers.actual mustEqual Option(150)
     }
 
     "give no pax count from splits it has no API splits" in {
       val flightWithSplits = flightWithPaxAndHistoricSplits( 45, 20, Set(),Map())
-      flightWithSplits.bestPaxSource(sourceOrderPreference).passengers.actual must beNone
+      flightWithSplits.apiFlight.bestPaxEstimate(sourceOrderPreference).passengers.actual must beNone
     }
 
     "give None for totalPaxFromApiExcludingTransfer when it doesn't have live API splits" in {
       val fws = flightWithPaxAndHistoricSplits( 100, 0, Set(),Map())
-      fws.bestPaxSource(sourceOrderPreference).passengers.actual === None
+      fws.apiFlight.bestPaxEstimate(sourceOrderPreference).passengers.actual === None
     }
 
     "give None for totalPaxFromApi when it doesn't have live API splits" in {
       val fws = flightWithPaxAndHistoricSplits(100, 0, Set(),Map())
-      fws.bestPaxSource(sourceOrderPreference).passengers.actual === None
+      fws.apiFlight.bestPaxEstimate(sourceOrderPreference).passengers.actual === None
     }
   }
 

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ApiFlightWithSplitsSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ApiFlightWithSplitsSpec.scala
@@ -146,7 +146,7 @@ class ApiFlightWithSplitsSpec extends Specification {
 
     "give a pax count from splits when it has API splits which does not include transfer pax" in {
       val flightWithSplits = flightWithPaxAndApiSplits(45, 20, Set(), Map(), scheduledAfterPaxSources)
-      flightWithSplits.apiFlight.bestPaxEstimate(sourceOrderPreference).passengers.getPcpPax mustEqual Option(45)
+      flightWithSplits.apiFlight.bestPaxEstimate(sourceOrderPreference).passengers.actual mustEqual Option(45)
     }
 
     "give a pax count from splits when it has API splits even when it is outside the trusted threshold" in {
@@ -178,7 +178,7 @@ class ApiFlightWithSplitsSpec extends Specification {
                                        ): ApiFlightWithSplits = {
     val flight: Arrival = ArrivalGenerator.arrival(
       feedSources = sources,
-      passengerSources = passengerSources,
+      passengerSources = passengerSources + (ApiFeedSource -> Passengers(Option(splitsDirect), Option(splitsTransfer))),
       sch = scheduled)
 
     ApiFlightWithSplits(flight, Set(splitsForPax(directPax = splitsDirect, transferPax = splitsTransfer, ApiSplitsWithHistoricalEGateAndFTPercentages)))

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalSpec.scala
@@ -137,4 +137,34 @@ class ArrivalSpec extends Specification {
       Arrival.isInRange(1, 10)(11) === false
     }
   }
+
+  "minutesOfPaxArrivals" >> {
+    "should return 0 when there are 0 total passengers" >> {
+      ArrivalGenerator.arrival(passengerSources = Map(ApiFeedSource -> Passengers(Option(0), None))).minutesOfPaxArrivals(List(ApiFeedSource)) === 0
+    }
+    "should return 1 when there are 1 total passengers" >> {
+      ArrivalGenerator.arrival(passengerSources = Map(ApiFeedSource -> Passengers(Option(1), None))).minutesOfPaxArrivals(List(ApiFeedSource)) === 1
+    }
+    "should return 1 when there are 20 total passengers" >> {
+      ArrivalGenerator.arrival(passengerSources = Map(ApiFeedSource -> Passengers(Option(20), None))).minutesOfPaxArrivals(List(ApiFeedSource)) === 1
+    }
+    "should return 2 when there are 21 total passengers" >> {
+      ArrivalGenerator.arrival(passengerSources = Map(ApiFeedSource -> Passengers(Option(21), None))).minutesOfPaxArrivals(List(ApiFeedSource)) === 2
+    }
+  }
+
+  "pcpRange" >> {
+    "should return 0L to 0L given an arrival with scheduled time 0L and 0 total passengers" >> {
+      ArrivalGenerator.arrival(sch = 0L,  passengerSources = Map(ApiFeedSource -> Passengers(Option(0), None))).pcpRange(List(ApiFeedSource)) === (0L to 0L by 60000)
+    }
+    "should return 0L to 0L given an arrival with scheduled time 0L and 1 total passengers" >> {
+      ArrivalGenerator.arrival(sch = 0L, passengerSources = Map(ApiFeedSource -> Passengers(Option(1), None))).pcpRange(List(ApiFeedSource)) === (0L to 0L by 60000)
+    }
+    "should return 0L to 0L given an arrival with scheduled time 0L and 20 total passengers" >> {
+      ArrivalGenerator.arrival(sch = 0L, passengerSources = Map(ApiFeedSource -> Passengers(Option(20), None))).pcpRange(List(ApiFeedSource)) === (0L to 0L by 60000)
+    }
+    "should return 0L to 60000L given an arrival with scheduled time 0L and 21 total passengers" >> {
+      ArrivalGenerator.arrival(sch = 0L, passengerSources = Map(ApiFeedSource -> Passengers(Option(21), None))).pcpRange(List(ApiFeedSource)) === (0L to 60000L by 60000)
+    }
+  }
 }

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalSpec.scala
@@ -4,6 +4,8 @@ import org.specs2.mutable.Specification
 import uk.gov.homeoffice.drt.ports._
 
 class ArrivalSpec extends Specification {
+
+
   "An Arrival" should {
     "Know it has no source of passengers when there are no sources" in {
       ArrivalGenerator.arrival(passengerSources = Map()).hasNoPaxSource shouldEqual true
@@ -115,6 +117,24 @@ class ArrivalSpec extends Specification {
       " then bestPcpPaxEstimate fallback to FeedSource " in {
       val arrival = arrivalBase.copy(PassengerSources = Map(AclFeedSource -> Passengers(Option(10), None)), FeedSources = Set(AclFeedSource))
       arrival.bestPaxEstimate(sourceOrderPreference) mustEqual PaxSource(aclFeedPaxSource._1, aclFeedPaxSource._2)
+    }
+  }
+
+  "isInRange" >> {
+    "should return true when the needle is equal to the start of the range" >> {
+      Arrival.isInRange(1, 10)(1) === true
+    }
+    "should return true when the needle is equal to the end of the range" >> {
+      Arrival.isInRange(1, 10)(10) === true
+    }
+    "should return true when the needle is between the start and end of the range" >> {
+      Arrival.isInRange(1, 10)(5) === true
+    }
+    "should return false when the needle is lower than the start of the range" >> {
+      Arrival.isInRange(1, 10)(0) === false
+    }
+    "should return false when the needle is higher than the end of the range" >> {
+      Arrival.isInRange(1, 10)(11) === false
     }
   }
 }

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ArrivalSpec.scala
@@ -118,6 +118,16 @@ class ArrivalSpec extends Specification {
       val arrival = arrivalBase.copy(PassengerSources = Map(AclFeedSource -> Passengers(Option(10), None)), FeedSources = Set(AclFeedSource))
       arrival.bestPaxEstimate(sourceOrderPreference) mustEqual PaxSource(aclFeedPaxSource._1, aclFeedPaxSource._2)
     }
+
+    "When there is a live feed with undefined pax and api with pax" >> {
+      "then bestPcpPaxEstimate should return the api pax" >> {
+        val arrival = arrivalBase.copy(PassengerSources = Map(
+          LiveFeedSource -> Passengers(None, Option(0)),
+          ApiFeedSource -> Passengers(Some(10), None)
+        ))
+        arrival.bestPcpPaxEstimate(sourceOrderPreference) must beSome(10)
+      }
+    }
   }
 
   "isInRange" >> {


### PR DESCRIPTION
Remove `bestPaxSource` from `ApiFlightWithSplits` as it contradicts the same function on `Arrival`
Fix some range logic and add tests