### PR TITLE
Drtii 1472 historic api not showing

### DIFF
--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/Arrival.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/Arrival.scala
@@ -221,6 +221,10 @@ case class Arrival(Operator: Option[Operator],
       Gate = if (incoming.Gate.exists(_.nonEmpty)) incoming.Gate else this.Gate,
       RedListPax = if (incoming.RedListPax.nonEmpty) incoming.RedListPax else this.RedListPax,
       MaxPax = if (incoming.MaxPax.nonEmpty) incoming.MaxPax else this.MaxPax,
+      FeedSources = FeedSources ++ incoming.FeedSources,
+      PassengerSources = incoming.PassengerSources.foldLeft(PassengerSources) {
+        case (acc, (key, updated)) => acc.updated(key, updated)
+      },
     )
 
   lazy val hasNoPaxSource: Boolean = !PassengerSources.values.exists(_.actual.nonEmpty)

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiff.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiff.scala
@@ -62,21 +62,13 @@ case class ArrivalsDiff(toUpdate: Map[UniqueArrival, Arrival], toRemove: Iterabl
       case (acc, (key, incomingArrival)) =>
         acc.get(key) match {
           case Some(existing) =>
-//            val (feedSources, paxSources) = fws.splits.foldLeft((arrival.FeedSources, arrival.PassengerSources)) {
-//              case ((accFs, accPs), split) if Set(ApiSplitsWithHistoricalEGateAndFTPercentages, Historical).contains(split.source) =>
-//                val totalPax = Option(split.totalPax)
-//                val transPax = if (split.transPax > 0) Option(split.transPax) else None
-//                val fs = if (split.source == ApiSplitsWithHistoricalEGateAndFTPercentages) ApiFeedSource else HistoricApiFeedSource
-//                (accFs + fs, accPs + (fs -> Passengers(totalPax, transPax)))
-//              case ((accFs, accPs), _) => (accFs, accPs)
-//            }
             val arrivalWithApiSources = incomingArrival.copy(
               FeedSources = existing.apiFlight.FeedSources ++ incomingArrival.FeedSources,
               PassengerSources = incomingArrival.PassengerSources.foldLeft(existing.apiFlight.PassengerSources) {
                 case (acc, (key, updated)) => acc.updated(key, updated)
               },
             )
-            acc + (key -> existing.copy(apiFlight = arrivalWithApiSources, lastUpdated = Option(nowMillis)))
+            acc + (key -> existing.copy(apiFlight = existing.apiFlight.update(incomingArrival), lastUpdated = Option(nowMillis)))
           case None =>
             acc + (key -> ApiFlightWithSplits(incomingArrival, Set(), Option(nowMillis)))
         }

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiff.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/ArrivalsDiff.scala
@@ -62,12 +62,6 @@ case class ArrivalsDiff(toUpdate: Map[UniqueArrival, Arrival], toRemove: Iterabl
       case (acc, (key, incomingArrival)) =>
         acc.get(key) match {
           case Some(existing) =>
-            val arrivalWithApiSources = incomingArrival.copy(
-              FeedSources = existing.apiFlight.FeedSources ++ incomingArrival.FeedSources,
-              PassengerSources = incomingArrival.PassengerSources.foldLeft(existing.apiFlight.PassengerSources) {
-                case (acc, (key, updated)) => acc.updated(key, updated)
-              },
-            )
             acc + (key -> existing.copy(apiFlight = existing.apiFlight.update(incomingArrival), lastUpdated = Option(nowMillis)))
           case None =>
             acc + (key -> ApiFlightWithSplits(incomingArrival, Set(), Option(nowMillis)))

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/Splits.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/Splits.scala
@@ -15,6 +15,14 @@ case class Splits(splits: Set[ApiPaxTypeAndQueueCount],
   lazy val totalPax: Int = Math.round(Splits.totalPax(splits)).toInt
   lazy val transPax: Int = Math.round(Splits.transferPax(splits)).toInt
   lazy val totalExcludingTransferPax: Double = totalPax - transPax
+
+  def isWithinThreshold(maybeLivePassengers: Option[Passengers], threshold: Double): Boolean = {
+    val portDirectPax = maybeLivePassengers.flatMap(_.getPcpPax).getOrElse(0)
+    if (totalExcludingTransferPax != 0) {
+      val diffPct = Math.abs(totalExcludingTransferPax - portDirectPax) / totalExcludingTransferPax
+      diffPct < threshold
+    } else false
+  }
 }
 
 object Splits {

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
@@ -2,8 +2,8 @@ package uk.gov.homeoffice.drt.arrivals
 
 import uk.gov.homeoffice.drt.DataUpdates.FlightUpdates
 import uk.gov.homeoffice.drt.arrivals.SplitsForArrivals.updateFlightWithSplits
-import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.{ApiSplitsWithHistoricalEGateAndFTPercentages, Historical}
-import uk.gov.homeoffice.drt.ports.{ApiFeedSource, FeedSource}
+import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages
+import uk.gov.homeoffice.drt.ports.{ApiFeedSource, FeedSource, LiveFeedSource}
 import upickle.default.{macroRW, _}
 
 
@@ -68,10 +68,10 @@ case class SplitsForArrivals(splits: Map[UniqueArrival, Set[Splits]]) extends Fl
         }
     }.toSet
     val updatedFlights = splits.foldLeft(flightsWithSplits.flights) {
-      case (acc, (key, incoming)) =>
+      case (acc, (key, incomingSplits)) =>
         acc.get(key) match {
-          case Some(flightWithSplits) =>
-            val updatedFlightWithSplits = updateFlightWithSplits(flightWithSplits, incoming, nowMillis)
+          case Some(existingFws) =>
+            val updatedFlightWithSplits = updateFlightWithSplits(existingFws, incomingSplits, nowMillis)
             acc + (key -> updatedFlightWithSplits)
           case None => acc
         }

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivals.scala
@@ -2,7 +2,7 @@ package uk.gov.homeoffice.drt.arrivals
 
 import uk.gov.homeoffice.drt.DataUpdates.FlightUpdates
 import uk.gov.homeoffice.drt.arrivals.SplitsForArrivals.updateFlightWithSplits
-import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages
+import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.{ApiSplitsWithHistoricalEGateAndFTPercentages, Historical}
 import uk.gov.homeoffice.drt.ports.{ApiFeedSource, FeedSource}
 import upickle.default.{macroRW, _}
 
@@ -60,11 +60,12 @@ case class SplitsForArrivals(splits: Map[UniqueArrival, Set[Splits]]) extends Fl
   }
 
   def applyTo(flightsWithSplits: FlightsWithSplits, nowMillis: Long, sourceOrderPreference: List[FeedSource]): (FlightsWithSplits, Set[Long]) = {
-    val minutesFromUpdates = splits.keys.flatMap { key =>
-      flightsWithSplits.flights.get(key) match {
-        case Some(fws) => fws.apiFlight.pcpRange(sourceOrderPreference)
-        case None => Iterable()
-      }
+    val minutesFromUpdates = splits.flatMap {
+      case (key, splits) =>
+        flightsWithSplits.flights.get(key) match {
+          case Some(fws) if splits.exists(_.source == ApiSplitsWithHistoricalEGateAndFTPercentages) => fws.apiFlight.pcpRange(sourceOrderPreference)
+          case _ => Iterable()
+        }
     }.toSet
     val updatedFlights = splits.foldLeft(flightsWithSplits.flights) {
       case (acc, (key, incoming)) =>

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ApiFlightWithSplitsSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/ApiFlightWithSplitsSpec.scala
@@ -16,28 +16,28 @@ class ApiFlightWithSplitsSpec extends Specification {
         val flightWithSplits = flightWithPaxAndApiSplits(41, 0, Set(LiveFeedSource),
           Map(LiveFeedSource -> Passengers(Option(40),Option(0))), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
-        flightWithSplits.isWithinThreshold(apiSplits) mustEqual true
+        apiSplits.isWithinThreshold(flightWithSplits.apiFlight.PassengerSources.get(LiveFeedSource), ApiFlightWithSplits.liveApiTolerance) mustEqual true
         flightWithSplits.hasValidApi mustEqual true
       }
 
       "and there are transfer pax only in the port feed data" in {
         val flightWithSplits = flightWithPaxAndApiSplits(21, 0, Set(LiveFeedSource), Map(LiveFeedSource -> Passengers(Option(40),Option(20))), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
-        flightWithSplits.isWithinThreshold(apiSplits) mustEqual true
+        apiSplits.isWithinThreshold(flightWithSplits.apiFlight.PassengerSources.get(LiveFeedSource), ApiFlightWithSplits.liveApiTolerance) mustEqual true
         flightWithSplits.hasValidApi mustEqual true
       }
 
       "and there are transfer pax only in the API data" in {
         val flightWithSplits = flightWithPaxAndApiSplits(41, 20, Set(LiveFeedSource), Map(LiveFeedSource -> Passengers(Option(40),Option(0))), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
-        flightWithSplits.isWithinThreshold(apiSplits) mustEqual true
+        apiSplits.isWithinThreshold(flightWithSplits.apiFlight.PassengerSources.get(LiveFeedSource), ApiFlightWithSplits.liveApiTolerance) mustEqual true
         flightWithSplits.hasValidApi mustEqual true
       }
 
       "and there are transfer pax both in the API data and in the port feed" in {
         val flightWithSplits = flightWithPaxAndApiSplits(21, 20, Set(LiveFeedSource), Map(LiveFeedSource -> Passengers(Option(40),Option(20))), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(s => s.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
-        flightWithSplits.isWithinThreshold(apiSplits) mustEqual true
+        apiSplits.isWithinThreshold(flightWithSplits.apiFlight.PassengerSources.get(LiveFeedSource), ApiFlightWithSplits.liveApiTolerance) mustEqual true
         flightWithSplits.hasValidApi mustEqual true
       }
 
@@ -51,28 +51,28 @@ class ApiFlightWithSplitsSpec extends Specification {
       "and there are no transfer pax" in {
         val flightWithSplits = flightWithPaxAndApiSplits(45, 0, Set(LiveFeedSource), Map(LiveFeedSource -> Passengers(Option(40),Option(0))), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
-        flightWithSplits.isWithinThreshold(apiSplits) mustEqual false
+        apiSplits.isWithinThreshold(flightWithSplits.apiFlight.PassengerSources.get(LiveFeedSource), ApiFlightWithSplits.liveApiTolerance) mustEqual false
         flightWithSplits.hasValidApi mustEqual false
       }
 
       "and there are transfer pax only in the port feed data" in {
         val flightWithSplits = flightWithPaxAndApiSplits(24, 0, Set(LiveFeedSource), Map(LiveFeedSource -> Passengers(Option(40),Option(20))), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
-        flightWithSplits.isWithinThreshold(apiSplits) mustEqual false
+        apiSplits.isWithinThreshold(flightWithSplits.apiFlight.PassengerSources.get(LiveFeedSource), ApiFlightWithSplits.liveApiTolerance) mustEqual false
         flightWithSplits.hasValidApi mustEqual false
       }
 
       "and there are transfer pax only in the API data" in {
         val flightWithSplits = flightWithPaxAndApiSplits(21, 25, Set(LiveFeedSource), Map(LiveFeedSource -> Passengers(Option(40),Option(0))), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(_.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
-        flightWithSplits.isWithinThreshold(apiSplits) mustEqual false
+        apiSplits.isWithinThreshold(flightWithSplits.apiFlight.PassengerSources.get(LiveFeedSource), ApiFlightWithSplits.liveApiTolerance) mustEqual false
         flightWithSplits.hasValidApi mustEqual false
       }
 
       "and there are transfer pax both in the API data and in the port feed" in {
         val flightWithSplits = flightWithPaxAndApiSplits(25, 25, Set(LiveFeedSource), Map(LiveFeedSource -> Passengers(Option(40),Option(20))), scheduledAfterPaxSources)
         val apiSplits = flightWithSplits.splits.find(s => s.source == SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages).get
-        flightWithSplits.isWithinThreshold(apiSplits) mustEqual false
+        apiSplits.isWithinThreshold(flightWithSplits.apiFlight.PassengerSources.get(LiveFeedSource), ApiFlightWithSplits.liveApiTolerance) mustEqual false
         flightWithSplits.hasValidApi mustEqual false
       }
     }
@@ -124,7 +124,7 @@ class ApiFlightWithSplitsSpec extends Specification {
         flightWithSplits.hasValidApi mustEqual true
         flightWithSplits.apiFlight.bestPcpPaxEstimate(sourceOrderPreference) must beSome(100)
         val paxPerQueue: Option[Map[Queues.Queue, Int]] = ApiSplitsToSplitRatio.paxPerQueueUsingBestSplitsAsRatio(flightWithSplits, sourceOrderPreference)
-        paxPerQueue must beSome(collection.Map(Queues.NonEeaDesk -> 100))
+        paxPerQueue must ===(Some(Map(Queues.NonEeaDesk -> 100)))
       }
     }
 

--- a/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivalsSpec.scala
+++ b/shared/src/test/scala/uk/gov/homeoffice/drt/arrivals/SplitsForArrivalsSpec.scala
@@ -67,21 +67,22 @@ class SplitsForArrivalsSpec extends Specification {
         val existingSplits2 = Splits(Set(ApiPaxTypeAndQueueCount(VisaNational, EGate, 1, None, None)), ApiSplitsWithHistoricalEGateAndFTPercentages, None, PaxNumbers)
         val newSplits = Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), ApiSplitsWithHistoricalEGateAndFTPercentages, None, PaxNumbers)
         val splitsForArrivals = SplitsForArrivals(Map(uniqueArrival -> Set(newSplits)))
-        val arrival = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
+        val arrival = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))//, passengerSources = Map(LiveFeedSource -> Passengers(Option(1), Some(0))), feedSources = Set(LiveFeedSource))
         val flights = FlightsWithSplits(Seq(ApiFlightWithSplits(arrival, Set(existingSplits1, existingSplits2))))
 
         val updated = splitsForArrivals.applyTo(flights, now, List())._1
 
-        updated === FlightsWithSplits(Seq(ApiFlightWithSplits(arrival.copy(FeedSources = Set(ApiFeedSource),
-          PassengerSources = Map(ApiFeedSource -> Passengers(Option(1), Some(0)))),
+        updated === FlightsWithSplits(Seq(ApiFlightWithSplits(arrival.copy(
+          FeedSources = Set(ApiFeedSource/*, LiveFeedSource*/),
+          PassengerSources = Map(ApiFeedSource -> Passengers(Option(1), Some(0))/*, LiveFeedSource -> Passengers(Option(1), Some(0))*/)),
           Set(newSplits, existingSplits1), Option(now))))
       }
     }
 
     "Given 2 splits and two arrivals, one with a new source and one with the same source" >> {
       "Then I should get a FlightsWithSplits containing the arrivals updated with the correct new splits" >> {
-        val arrival1 = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"))
-        val arrival2 = ArrivalGenerator.arrival(iata = "FR1234", terminal = T1, origin = PortCode("JFK"))
+        val arrival1 = ArrivalGenerator.arrival(iata = "BA0001", terminal = T1, origin = PortCode("JFK"), passengerSources = Map(LiveFeedSource -> Passengers(Option(1), Some(0))))
+        val arrival2 = ArrivalGenerator.arrival(iata = "FR1234", terminal = T1, origin = PortCode("JFK"), passengerSources = Map(LiveFeedSource -> Passengers(Option(1), Some(0))))
         val existingSplits1 = Splits(Set(ApiPaxTypeAndQueueCount(VisaNational, NonEeaDesk, 1, None, None)), Historical, None, PaxNumbers)
         val existingSplits2 = Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 1, None, None)), Historical, None, PaxNumbers)
         val newSplits1 = Splits(Set(ApiPaxTypeAndQueueCount(EeaNonMachineReadable, EeaDesk, 1, None, None)), Historical, None, PaxNumbers)


### PR DESCRIPTION
Tidy up `applyTo` for `ArrivalsDiff` - remove unnecessary splits calculations etc
Move splits validity function to splits object to make it more accessible