### PR TITLE
Drtii 1758 default egate processing times are 60 times too high

### DIFF
--- a/shared/src/main/scala/uk/gov/homeoffice/drt/ports/AirportConfig.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/ports/AirportConfig.scala
@@ -92,6 +92,14 @@ case class AirportConfig(portCode: PortCode,
               assert(minMaxDesksByTerminalQueue24Hrs(terminal).contains(tQueue), s"Missing min/max desks for $tQueue for terminal $terminal @ $portCode")
           }
     }
+    terminalProcessingTimes.foreach {
+      case (terminal, procTimes) =>
+        procTimes.foreach {
+          case (paxTypeAndQueue, procTime) =>
+            assert(procTime > 0.3, s"Processing time for $paxTypeAndQueue at $terminal is too low @ $portCode (${procTime * 60} <= 20s)")
+            assert(procTime < 3, s"Processing time for $paxTypeAndQueue at $terminal is too high @ $portCode (${procTime * 60} >= 180s)")
+        }
+    }
   }
 
   def minDesksByTerminalAndQueue24Hrs: Map[Terminal, Map[Queue, IndexedSeq[Int]]] = minMaxDesksByTerminalQueue24Hrs.mapValues(_.mapValues(_._1.toIndexedSeq).view.toMap).view.toMap

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/ports/config/AirportConfigDefaults.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/ports/config/AirportConfigDefaults.scala
@@ -66,9 +66,9 @@ object AirportConfigDefaults {
     eeaNonMachineReadableToDesk -> ProcTimes.eea / 60,
     gbrNationalToDesk -> ProcTimes.gbr / 60,
     gbrNationalChildToDesk -> ProcTimes.gbr / 60,
-    b5jsskToEGate -> ProcTimes.egates,
-    eeaMachineReadableToEGate -> ProcTimes.egates,
-    gbrNationalToEgate -> ProcTimes.egates,
+    b5jsskToEGate -> ProcTimes.egates / 60,
+    eeaMachineReadableToEGate -> ProcTimes.egates / 60,
+    gbrNationalToEgate -> ProcTimes.egates / 60,
     visaNationalToDesk -> ProcTimes.vn / 60,
     nonVisaNationalToDesk -> ProcTimes.nvn / 60
   )

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/ports/config/Lhr.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/ports/config/Lhr.scala
@@ -98,7 +98,7 @@ object Lhr extends AirportConfigLike {
         nonVisaNationalToDesk -> ProcTimesT2.nvn / 60,
         visaNationalToFastTrack -> ProcTimesT2.vn / 60,
         nonVisaNationalToFastTrack -> ProcTimesT2.nvn / 60,
-        transitToTransfer -> 0d,
+        transitToTransfer -> 50d / 60,
       ),
       T3 -> Map(
         b5jsskToDesk -> ProcTimesT3.b5jssk / 60,
@@ -115,7 +115,7 @@ object Lhr extends AirportConfigLike {
         nonVisaNationalToDesk -> ProcTimesT3.nvn / 60,
         visaNationalToFastTrack -> ProcTimesT3.vn / 60,
         nonVisaNationalToFastTrack -> ProcTimesT3.nvn / 60,
-        transitToTransfer -> 0d,
+        transitToTransfer -> 50d / 60,
       ),
       T4 -> Map(
         b5jsskToDesk -> ProcTimesT4.b5jssk / 60,
@@ -132,7 +132,7 @@ object Lhr extends AirportConfigLike {
         nonVisaNationalToDesk -> ProcTimesT4.nvn / 60,
         visaNationalToFastTrack -> ProcTimesT4.vn / 60,
         nonVisaNationalToFastTrack -> ProcTimesT4.nvn / 60,
-        transitToTransfer -> 0d,
+        transitToTransfer -> 50d / 60,
       ),
       T5 -> Map(
         b5jsskToDesk -> ProcTimesT5.b5jssk / 60,
@@ -149,7 +149,7 @@ object Lhr extends AirportConfigLike {
         nonVisaNationalToDesk -> ProcTimesT5.nvn / 60,
         visaNationalToFastTrack -> ProcTimesT5.vn / 60,
         nonVisaNationalToFastTrack -> ProcTimesT5.nvn / 60,
-        transitToTransfer -> 0d,
+        transitToTransfer -> 50d / 60,
       )
     ),
     minMaxDesksByTerminalQueue24Hrs = Map(


### PR DESCRIPTION
Fix misconfigured default egate times
Add assertions to guard against high and low processing times: 20 <= p <= 180