### PR TITLE
Drtii 1864 egate uptake historic simulation vs bx

### DIFF
--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/dao/EgateSimulationDao.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/dao/EgateSimulationDao.scala
@@ -14,10 +14,6 @@ case class EgateSimulationDao()
                              (implicit ec: ExecutionContext) {
   val table: TableQuery[EgateSimulationTable] = TableQuery[EgateSimulationTable]
 
-  def printlnCreateStatements(): Unit = {
-    println(table.schema.createStatements.mkString(";\n") + ";")
-  }
-
   def get(uuid: String): DBIOAction[Option[EgateSimulation], NoStream, Effect.Read] =
     table
       .filter(_.uuid === uuid)
@@ -36,8 +32,6 @@ case class EgateSimulationDao()
       .result
       .map(_.map(r => EgateSimulationSerialisation(r)).headOption)
 
-  def insertOrUpdate: EgateSimulation => DBIOAction[Int, NoStream, Effect.Write with Effect.Transactional] = {
-    simulation =>
-      table.insertOrUpdate(EgateSimulationSerialisation(simulation))
-  }
+  def insertOrUpdate(simulation: EgateSimulation): DBIOAction[Int, NoStream, Effect.Write with Effect.Transactional] =
+    table.insertOrUpdate(EgateSimulationSerialisation(simulation))
 }

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/dao/EgateSimulationDao.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/dao/EgateSimulationDao.scala
@@ -1,0 +1,43 @@
+package uk.gov.homeoffice.drt.db.dao
+
+import slick.dbio.Effect
+import slick.jdbc.PostgresProfile.api._
+import uk.gov.homeoffice.drt.db.serialisers.{EgateSimulation, EgateSimulationRequest, EgateSimulationSerialisation}
+import uk.gov.homeoffice.drt.db.tables.EgateSimulationTable
+import uk.gov.homeoffice.drt.time.SDate
+
+import java.sql.Timestamp
+import scala.concurrent.ExecutionContext
+
+
+case class EgateSimulationDao()
+                             (implicit ec: ExecutionContext) {
+  val table: TableQuery[EgateSimulationTable] = TableQuery[EgateSimulationTable]
+
+  def printlnCreateStatements(): Unit = {
+    println(table.schema.createStatements.mkString(";\n") + ";")
+  }
+
+  def get(uuid: String): DBIOAction[Option[EgateSimulation], NoStream, Effect.Read] =
+    table
+      .filter(_.uuid === uuid)
+      .result
+      .map(_.map(r => EgateSimulationSerialisation(r)).headOption)
+
+  def get(request: EgateSimulationRequest): DBIOAction[Option[EgateSimulation], NoStream, Effect.Read] =
+    table
+      .filter(r =>
+        r.startDate === new Timestamp(SDate(request.startDate).millisSinceEpoch) &&
+          r.endDate === new Timestamp(SDate(request.endDate).millisSinceEpoch) &&
+          r.terminal === request.terminal.toString &&
+          r.uptakePercentage === request.uptakePercentage &&
+          r.parentChildRatio === request.parentChildRatio
+      )
+      .result
+      .map(_.map(r => EgateSimulationSerialisation(r)).headOption)
+
+  def insertOrUpdate: EgateSimulation => DBIOAction[Int, NoStream, Effect.Write with Effect.Transactional] = {
+    simulation =>
+      table.insertOrUpdate(EgateSimulationSerialisation(simulation))
+  }
+}

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/dao/FlightDao.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/dao/FlightDao.scala
@@ -9,7 +9,7 @@ import uk.gov.homeoffice.drt.db.serialisers.FlightSerialiser
 import uk.gov.homeoffice.drt.db.tables.{FlightRow, FlightTable}
 import uk.gov.homeoffice.drt.ports.Terminals.Terminal
 import uk.gov.homeoffice.drt.ports.{FeedSource, PortCode}
-import uk.gov.homeoffice.drt.time.{DateRange, LocalDate, SDate, UtcDate}
+import uk.gov.homeoffice.drt.time.{DateLike, DateRange, LocalDate, SDate, UtcDate}
 
 import java.sql.Timestamp
 import scala.concurrent.{ExecutionContext, Future}
@@ -22,7 +22,7 @@ case class FlightDao()
   def flightsForPcpDateRange(portCode: PortCode,
                              paxFeedSourceOrder: List[FeedSource],
                              execute: DBIOAction[(UtcDate, Seq[ApiFlightWithSplits]), NoStream, Effect.Read] => Future[(UtcDate, Seq[ApiFlightWithSplits])]
-                            ): (LocalDate, LocalDate, Seq[Terminal]) => Source[(UtcDate, Seq[ApiFlightWithSplits]), NotUsed] = {
+                            ): (DateLike, DateLike, Seq[Terminal]) => Source[(UtcDate, Seq[ApiFlightWithSplits]), NotUsed] = {
     val getFlights = getForTerminalsUtcDate(portCode)
 
     (start, end, terminals) =>

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/dao/FlightDao.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/dao/FlightDao.scala
@@ -26,7 +26,9 @@ case class FlightDao()
     val getFlights = getForTerminalsUtcDate(portCode)
 
     (start, end, terminals) =>
-      val utcStart = SDate(start).addDays(-1).toUtcDate
+      val startSdate = SDate(start)
+      val endSdate = SDate(end).addDays(1).addMinutes(-1)
+      val utcStart = startSdate.addDays(-1).toUtcDate
       val endPlusADay = SDate(end).addDays(1).toUtcDate
       val utcEnd = UtcDate(endPlusADay.year, endPlusADay.month, endPlusADay.day)
       Source(DateRange(utcStart, utcEnd))
@@ -34,7 +36,7 @@ case class FlightDao()
           execute(
             getFlights(terminals, date)
               .map { flights =>
-                val relevantFlightsForDates = flights.filter(_.apiFlight.hasPcpDuring(SDate(start), SDate(end).addDays(1).addMinutes(-1), paxFeedSourceOrder))
+                val relevantFlightsForDates = flights.filter(_.apiFlight.hasPcpDuring(startSdate, endSdate, paxFeedSourceOrder))
                 date -> relevantFlightsForDates
               }
           )

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisation.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisation.scala
@@ -28,11 +28,11 @@ case class EgateSimulation(uuid: String,
 object EgateSimulationSerialisation {
   def apply(row: EgateSimulationRow): EgateSimulation = {
     val maybeResponse = for {
-      content <- row.content
+      csvContent <- row.csvContent
       averageDifference <- row.averageDifference
       standardDeviation <- row.standardDeviation
     } yield EgateSimulationResponse(
-      csvContent = content,
+      csvContent = csvContent,
       averageDifference = averageDifference,
       standardDeviation = standardDeviation,
     )
@@ -61,7 +61,7 @@ object EgateSimulationSerialisation {
       uptakePercentage = simulation.request.uptakePercentage,
       parentChildRatio = simulation.request.parentChildRatio,
       status = simulation.status,
-      content = simulation.response.map(_.csvContent),
+      csvContent = simulation.response.map(_.csvContent),
       averageDifference = simulation.response.map(_.averageDifference),
       standardDeviation = simulation.response. map(_.standardDeviation),
       createdAt = new Timestamp(simulation.createdAt.millisSinceEpoch),

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisation.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisation.scala
@@ -16,9 +16,9 @@ case class EgateSimulationRequest(startDate: UtcDate,
 case class EgateSimulation(uuid: String,
                            request: EgateSimulationRequest,
                            status: String,
+                           content: Option[String],
                            createdAt: SDateLike,
                           )
-
 
 object EgateSimulationSerialisation {
   def apply(row: EgateSimulationRow): EgateSimulation =
@@ -32,6 +32,7 @@ object EgateSimulationSerialisation {
         parentChildRatio = row.parentChildRatio,
       ),
       status = row.status,
+      content = row.content,
       createdAt = SDate(row.createdAt.getTime),
     )
 
@@ -44,6 +45,7 @@ object EgateSimulationSerialisation {
       uptakePercentage = simulation.request.uptakePercentage,
       parentChildRatio = simulation.request.parentChildRatio,
       status = simulation.status,
+      content = simulation.content,
       createdAt = new Timestamp(simulation.createdAt.millisSinceEpoch),
     )
 }

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisation.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisation.scala
@@ -1,0 +1,49 @@
+package uk.gov.homeoffice.drt.db.serialisers
+
+import uk.gov.homeoffice.drt.db.tables.EgateSimulationRow
+import uk.gov.homeoffice.drt.ports.Terminals.Terminal
+import uk.gov.homeoffice.drt.time.{SDate, SDateLike, UtcDate}
+
+import java.sql.Timestamp
+
+case class EgateSimulationRequest(startDate: UtcDate,
+                                  endDate: UtcDate,
+                                  terminal: Terminal,
+                                  uptakePercentage: Double,
+                                  parentChildRatio: Double,
+                                 )
+
+case class EgateSimulation(uuid: String,
+                           request: EgateSimulationRequest,
+                           status: String,
+                           createdAt: SDateLike,
+                          )
+
+
+object EgateSimulationSerialisation {
+  def apply(row: EgateSimulationRow): EgateSimulation =
+    EgateSimulation(
+      uuid = row.uuid,
+      EgateSimulationRequest(
+        startDate = SDate(row.startDate.getTime).toUtcDate,
+        endDate = SDate(row.endDate.getTime).toUtcDate,
+        terminal = Terminal(row.terminal),
+        uptakePercentage = row.uptakePercentage,
+        parentChildRatio = row.parentChildRatio,
+      ),
+      status = row.status,
+      createdAt = SDate(row.createdAt.getTime),
+    )
+
+  def apply(simulation: EgateSimulation): EgateSimulationRow =
+    EgateSimulationRow(
+      uuid = simulation.uuid,
+      startDate = new Timestamp(SDate(simulation.request.startDate).millisSinceEpoch),
+      endDate = new Timestamp(SDate(simulation.request.endDate).millisSinceEpoch),
+      terminal = simulation.request.terminal.toString,
+      uptakePercentage = simulation.request.uptakePercentage,
+      parentChildRatio = simulation.request.parentChildRatio,
+      status = simulation.status,
+      createdAt = new Timestamp(simulation.createdAt.millisSinceEpoch),
+    )
+}

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/tables/EgateSimulationTable.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/tables/EgateSimulationTable.scala
@@ -1,0 +1,41 @@
+package uk.gov.homeoffice.drt.db.tables
+
+import slick.jdbc.PostgresProfile.api._
+
+import java.sql.Timestamp
+
+case class EgateSimulationRow(uuid: String,
+                              startDate: Timestamp,
+                              endDate: Timestamp,
+                              terminal: String,
+                              uptakePercentage: Double,
+                              parentChildRatio: Double,
+                              status: String,
+                              createdAt: Timestamp,
+                             )
+
+
+class EgateSimulationTable(tag: Tag) extends Table[EgateSimulationRow](tag, "egate_simulation") {
+  def uuid: Rep[String] = column[String]("id", O.Length(255, varying = true))
+
+  def startDate: Rep[Timestamp] = column[Timestamp]("start_date")
+
+  def endDate: Rep[Timestamp] = column[Timestamp]("end_date")
+
+  def terminal: Rep[String] = column[String]("terminal", O.Length(64, varying = true))
+
+  def uptakePercentage: Rep[Double] = column[Double]("uptake_percentage")
+
+  def parentChildRatio: Rep[Double] = column[Double]("parent_child_ratio")
+
+  def status: Rep[String] = column[String]("status", O.Length(64, varying = true))
+
+  def createdAt: Rep[Timestamp] = column[Timestamp]("created_at")
+
+
+  def * = (uuid, startDate, endDate, terminal, uptakePercentage, parentChildRatio, status, createdAt) <> (EgateSimulationRow.tupled, EgateSimulationRow.unapply)
+
+  val key = primaryKey("egate_simulation_idx", (startDate, endDate, terminal, uptakePercentage, parentChildRatio))
+
+  val uuidIndex = index("egate_simulation_parameters_uuid", uuid, unique = true)
+}

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/tables/EgateSimulationTable.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/tables/EgateSimulationTable.scala
@@ -12,6 +12,8 @@ case class EgateSimulationRow(uuid: String,
                               parentChildRatio: Double,
                               status: String,
                               content: Option[String],
+                              averageDifference: Option[Double] = None,
+                              standardDeviation: Option[Double] = None,
                               createdAt: Timestamp,
                              )
 
@@ -33,10 +35,14 @@ class EgateSimulationTable(tag: Tag) extends Table[EgateSimulationRow](tag, "ega
 
   def content: Rep[Option[String]] = column[Option[String]]("content")
 
+  def averageDifference: Rep[Option[Double]] = column[Option[Double]]("average_difference")
+
+  def standardDeviation: Rep[Option[Double]] = column[Option[Double]]("standard_deviation")
+
   def createdAt: Rep[Timestamp] = column[Timestamp]("created_at")
 
 
-  def * = (uuid, startDate, endDate, terminal, uptakePercentage, parentChildRatio, status, content, createdAt) <> (EgateSimulationRow.tupled, EgateSimulationRow.unapply)
+  def * = (uuid, startDate, endDate, terminal, uptakePercentage, parentChildRatio, status, content, averageDifference, standardDeviation, createdAt) <> (EgateSimulationRow.tupled, EgateSimulationRow.unapply)
 
   val key = primaryKey("egate_simulation_idx", (startDate, endDate, terminal, uptakePercentage, parentChildRatio))
 

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/tables/EgateSimulationTable.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/tables/EgateSimulationTable.scala
@@ -57,7 +57,7 @@ class EgateSimulationTable(tag: Tag) extends Table[EgateSimulationRow](tag, "ega
   def * = (uuid, port, terminal, startDate, endDate, uptakePercentage, parentChildRatio, status, csvContent,
     meanAbsolutePercentageError, standardDeviation, bias, correlationCoefficient, rSquaredError, createdAt) <> (EgateSimulationRow.tupled, EgateSimulationRow.unapply)
 
-  val key = primaryKey("egate_simulation_idx", (startDate, endDate, terminal, uptakePercentage, parentChildRatio))
+  val key = primaryKey("egate_simulation_idx", (port, terminal, startDate, endDate, uptakePercentage, parentChildRatio))
 
   val uuidIndex = index("egate_simulation_parameters_uuid", uuid, unique = true)
 }

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/tables/EgateSimulationTable.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/tables/EgateSimulationTable.scala
@@ -11,6 +11,7 @@ case class EgateSimulationRow(uuid: String,
                               uptakePercentage: Double,
                               parentChildRatio: Double,
                               status: String,
+                              content: Option[String],
                               createdAt: Timestamp,
                              )
 
@@ -30,10 +31,12 @@ class EgateSimulationTable(tag: Tag) extends Table[EgateSimulationRow](tag, "ega
 
   def status: Rep[String] = column[String]("status", O.Length(64, varying = true))
 
+  def content: Rep[Option[String]] = column[Option[String]]("content")
+
   def createdAt: Rep[Timestamp] = column[Timestamp]("created_at")
 
 
-  def * = (uuid, startDate, endDate, terminal, uptakePercentage, parentChildRatio, status, createdAt) <> (EgateSimulationRow.tupled, EgateSimulationRow.unapply)
+  def * = (uuid, startDate, endDate, terminal, uptakePercentage, parentChildRatio, status, content, createdAt) <> (EgateSimulationRow.tupled, EgateSimulationRow.unapply)
 
   val key = primaryKey("egate_simulation_idx", (startDate, endDate, terminal, uptakePercentage, parentChildRatio))
 

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/tables/EgateSimulationTable.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/tables/EgateSimulationTable.scala
@@ -11,7 +11,7 @@ case class EgateSimulationRow(uuid: String,
                               uptakePercentage: Double,
                               parentChildRatio: Double,
                               status: String,
-                              content: Option[String],
+                              csvContent: Option[String],
                               averageDifference: Option[Double] = None,
                               standardDeviation: Option[Double] = None,
                               createdAt: Timestamp,
@@ -33,7 +33,7 @@ class EgateSimulationTable(tag: Tag) extends Table[EgateSimulationRow](tag, "ega
 
   def status: Rep[String] = column[String]("status", O.Length(64, varying = true))
 
-  def content: Rep[Option[String]] = column[Option[String]]("content")
+  def csvContent: Rep[Option[String]] = column[Option[String]]("csv_content")
 
   def averageDifference: Rep[Option[Double]] = column[Option[Double]]("average_difference")
 
@@ -42,7 +42,7 @@ class EgateSimulationTable(tag: Tag) extends Table[EgateSimulationRow](tag, "ega
   def createdAt: Rep[Timestamp] = column[Timestamp]("created_at")
 
 
-  def * = (uuid, startDate, endDate, terminal, uptakePercentage, parentChildRatio, status, content, averageDifference, standardDeviation, createdAt) <> (EgateSimulationRow.tupled, EgateSimulationRow.unapply)
+  def * = (uuid, startDate, endDate, terminal, uptakePercentage, parentChildRatio, status, csvContent, averageDifference, standardDeviation, createdAt) <> (EgateSimulationRow.tupled, EgateSimulationRow.unapply)
 
   val key = primaryKey("egate_simulation_idx", (startDate, endDate, terminal, uptakePercentage, parentChildRatio))
 

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/db/tables/EgateSimulationTable.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/db/tables/EgateSimulationTable.scala
@@ -5,15 +5,19 @@ import slick.jdbc.PostgresProfile.api._
 import java.sql.Timestamp
 
 case class EgateSimulationRow(uuid: String,
+                              port: String,
+                              terminal: String,
                               startDate: Timestamp,
                               endDate: Timestamp,
-                              terminal: String,
                               uptakePercentage: Double,
                               parentChildRatio: Double,
                               status: String,
                               csvContent: Option[String],
-                              averageDifference: Option[Double] = None,
-                              standardDeviation: Option[Double] = None,
+                              meanAbsolutePercentageError: Option[Double],
+                              standardDeviation: Option[Double],
+                              bias: Option[Double],
+                              correlationCoefficient: Option[Double],
+                              rSquaredError: Option[Double],
                               createdAt: Timestamp,
                              )
 
@@ -21,11 +25,13 @@ case class EgateSimulationRow(uuid: String,
 class EgateSimulationTable(tag: Tag) extends Table[EgateSimulationRow](tag, "egate_simulation") {
   def uuid: Rep[String] = column[String]("id", O.Length(255, varying = true))
 
+  def port: Rep[String] = column[String]("port", O.Length(64, varying = true))
+
+  def terminal: Rep[String] = column[String]("terminal", O.Length(64, varying = true))
+
   def startDate: Rep[Timestamp] = column[Timestamp]("start_date")
 
   def endDate: Rep[Timestamp] = column[Timestamp]("end_date")
-
-  def terminal: Rep[String] = column[String]("terminal", O.Length(64, varying = true))
 
   def uptakePercentage: Rep[Double] = column[Double]("uptake_percentage")
 
@@ -35,14 +41,21 @@ class EgateSimulationTable(tag: Tag) extends Table[EgateSimulationRow](tag, "ega
 
   def csvContent: Rep[Option[String]] = column[Option[String]]("csv_content")
 
-  def averageDifference: Rep[Option[Double]] = column[Option[Double]]("average_difference")
+  def meanAbsolutePercentageError: Rep[Option[Double]] = column[Option[Double]]("mean_absolute_percentage_error")
 
   def standardDeviation: Rep[Option[Double]] = column[Option[Double]]("standard_deviation")
+
+  def bias: Rep[Option[Double]] = column[Option[Double]]("bias")
+
+  def correlationCoefficient: Rep[Option[Double]] = column[Option[Double]]("correlation_coefficient")
+
+  def rSquaredError: Rep[Option[Double]] = column[Option[Double]]("r_squared_error")
 
   def createdAt: Rep[Timestamp] = column[Timestamp]("created_at")
 
 
-  def * = (uuid, startDate, endDate, terminal, uptakePercentage, parentChildRatio, status, csvContent, averageDifference, standardDeviation, createdAt) <> (EgateSimulationRow.tupled, EgateSimulationRow.unapply)
+  def * = (uuid, port, terminal, startDate, endDate, uptakePercentage, parentChildRatio, status, csvContent,
+    meanAbsolutePercentageError, standardDeviation, bias, correlationCoefficient, rSquaredError, createdAt) <> (EgateSimulationRow.tupled, EgateSimulationRow.unapply)
 
   val key = primaryKey("egate_simulation_idx", (startDate, endDate, terminal, uptakePercentage, parentChildRatio))
 

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/db/dao/EgateSimulationDaoTest.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/db/dao/EgateSimulationDaoTest.scala
@@ -39,6 +39,7 @@ class EgateSimulationDaoTest extends AnyWordSpec with Matchers with BeforeAndAft
       uptakePercentage = 50,
       parentChildRatio = 0.5),
     status = "active",
+    content = None,
     createdAt = date,
   )
 
@@ -55,7 +56,7 @@ class EgateSimulationDaoTest extends AnyWordSpec with Matchers with BeforeAndAft
 
       Await.result(TestDatabase.run(dao.insertOrUpdate(initialSimulation)), 2.second)
 
-      val updatedSimulation = initialSimulation.copy(status = "completed")
+      val updatedSimulation = initialSimulation.copy(status = "completed", content = Some("nice csv content"))
       Await.result(TestDatabase.run(dao.insertOrUpdate(updatedSimulation)), 2.second)
 
       val retrievedSimulation = Await.result(TestDatabase.run(dao.get(updatedSimulation.uuid)), 2.second)

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/db/dao/EgateSimulationDaoTest.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/db/dao/EgateSimulationDaoTest.scala
@@ -1,0 +1,79 @@
+package uk.gov.homeoffice.drt.db.dao
+
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.homeoffice.drt.db.TestDatabase
+import uk.gov.homeoffice.drt.db.serialisers.{EgateSimulation, EgateSimulationRequest}
+import uk.gov.homeoffice.drt.ports.Terminals.T1
+import uk.gov.homeoffice.drt.time.{SDate, SDateLike}
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+
+class EgateSimulationDaoTest extends AnyWordSpec with Matchers with BeforeAndAfter {
+
+  import TestDatabase.profile.api._
+
+  private val dao: EgateSimulationDao = EgateSimulationDao()
+
+  SchemaUtils.printStatements(dao.table.schema.createStatements)
+
+  before {
+    Await.result(
+      TestDatabase.run(DBIO.seq(
+        dao.table.schema.dropIfExists,
+        dao.table.schema.createIfNotExists)
+      ), 2.second)
+  }
+
+  val date: SDateLike = SDate("2023-10-01T00:00:00Z")
+
+  val simulation: EgateSimulation = EgateSimulation(
+    uuid = "test-uuid",
+    EgateSimulationRequest(
+      startDate = date.toUtcDate,
+      endDate = date.toUtcDate,
+      terminal = T1,
+      uptakePercentage = 50,
+      parentChildRatio = 0.5),
+    status = "active",
+    createdAt = date,
+  )
+
+  "insertOrUpdate" should {
+    "insert a new egate simulation" in {
+      Await.result(TestDatabase.run(dao.insertOrUpdate(simulation)), 2.second)
+
+      val retrievedSimulation = Await.result(TestDatabase.run(dao.get(simulation.uuid)), 2.second)
+      retrievedSimulation shouldBe Some(simulation)
+    }
+
+    "update an existing egate simulation" in {
+      val initialSimulation = simulation
+
+      Await.result(TestDatabase.run(dao.insertOrUpdate(initialSimulation)), 2.second)
+
+      val updatedSimulation = initialSimulation.copy(status = "completed")
+      Await.result(TestDatabase.run(dao.insertOrUpdate(updatedSimulation)), 2.second)
+
+      val retrievedSimulation = Await.result(TestDatabase.run(dao.get(updatedSimulation.uuid)), 2.second)
+      retrievedSimulation shouldBe Some(updatedSimulation)
+    }
+  }
+
+  "get" should {
+    "retrieve an egate simulation by UUID" in {
+      Await.result(TestDatabase.run(dao.insertOrUpdate(simulation)), 2.second)
+
+      val retrievedSimulation = Await.result(TestDatabase.run(dao.get(simulation.uuid)), 2.second)
+      retrievedSimulation shouldBe Some(simulation)
+    }
+
+    "return None for a non-existent UUID" in {
+      val retrievedSimulation = Await.result(TestDatabase.run(dao.get("non-existent-uuid")), 2.second)
+      retrievedSimulation shouldBe None
+    }
+  }
+}

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/db/dao/EgateSimulationDaoTest.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/db/dao/EgateSimulationDaoTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.homeoffice.drt.db.TestDatabase
 import uk.gov.homeoffice.drt.db.serialisers.{EgateSimulation, EgateSimulationRequest, EgateSimulationResponse}
+import uk.gov.homeoffice.drt.ports.PortCode
 import uk.gov.homeoffice.drt.ports.Terminals.T1
 import uk.gov.homeoffice.drt.time.{SDate, SDateLike}
 
@@ -33,16 +34,20 @@ class EgateSimulationDaoTest extends AnyWordSpec with Matchers with BeforeAndAft
   val simulation: EgateSimulation = EgateSimulation(
     uuid = "test-uuid",
     EgateSimulationRequest(
+      portCode = PortCode("LHR"),
+      terminal = T1,
       startDate = date.toUtcDate,
       endDate = date.toUtcDate,
-      terminal = T1,
       uptakePercentage = 50,
       parentChildRatio = 0.5),
     status = "active",
     response = Some(EgateSimulationResponse(
       csvContent = "header1,header2\nvalue1,value2",
-      averageDifference = 5.0,
+      meanAbsolutePercentageError = 5.0,
       standardDeviation = 1.0,
+      bias = 0.1,
+      correlationCoefficient = 0.9,
+      rSquaredError = 0.8,
     )),
     createdAt = date,
   )
@@ -60,7 +65,7 @@ class EgateSimulationDaoTest extends AnyWordSpec with Matchers with BeforeAndAft
 
       Await.result(TestDatabase.run(dao.insertOrUpdate(initialSimulation)), 2.second)
 
-      val updatedSimulation = initialSimulation.copy(status = "completed", response = Some(EgateSimulationResponse("nice csv content", 6.0, 1.5)))
+      val updatedSimulation = initialSimulation.copy(status = "completed", response = Some(EgateSimulationResponse("nice csv content", 6.0, 1.5, 0.2, 0.95, 0.85)))
       Await.result(TestDatabase.run(dao.insertOrUpdate(updatedSimulation)), 2.second)
 
       val retrievedSimulation = Await.result(TestDatabase.run(dao.get(updatedSimulation.uuid)), 2.second)

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/db/dao/EgateSimulationDaoTest.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/db/dao/EgateSimulationDaoTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.homeoffice.drt.db.TestDatabase
-import uk.gov.homeoffice.drt.db.serialisers.{EgateSimulation, EgateSimulationRequest}
+import uk.gov.homeoffice.drt.db.serialisers.{EgateSimulation, EgateSimulationRequest, EgateSimulationResponse}
 import uk.gov.homeoffice.drt.ports.Terminals.T1
 import uk.gov.homeoffice.drt.time.{SDate, SDateLike}
 
@@ -39,7 +39,11 @@ class EgateSimulationDaoTest extends AnyWordSpec with Matchers with BeforeAndAft
       uptakePercentage = 50,
       parentChildRatio = 0.5),
     status = "active",
-    content = None,
+    response = Some(EgateSimulationResponse(
+      csvContent = "header1,header2\nvalue1,value2",
+      averageDifference = 5.0,
+      standardDeviation = 1.0,
+    )),
     createdAt = date,
   )
 
@@ -56,7 +60,7 @@ class EgateSimulationDaoTest extends AnyWordSpec with Matchers with BeforeAndAft
 
       Await.result(TestDatabase.run(dao.insertOrUpdate(initialSimulation)), 2.second)
 
-      val updatedSimulation = initialSimulation.copy(status = "completed", content = Some("nice csv content"))
+      val updatedSimulation = initialSimulation.copy(status = "completed", response = Some(EgateSimulationResponse("nice csv content", 6.0, 1.5)))
       Await.result(TestDatabase.run(dao.insertOrUpdate(updatedSimulation)), 2.second)
 
       val retrievedSimulation = Await.result(TestDatabase.run(dao.get(updatedSimulation.uuid)), 2.second)

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisationTest.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisationTest.scala
@@ -1,0 +1,29 @@
+package uk.gov.homeoffice.drt.db.serialisers
+
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.homeoffice.drt.ports.Terminals.T1
+import uk.gov.homeoffice.drt.time.{SDate, UtcDate}
+
+class EgateSimulationSerialisationTest extends AnyWordSpec {
+  "EgateSimulationSerialisation" should {
+    "serialize and deserialize EgateSimulationRow correctly" in {
+      val simulation = EgateSimulation(
+        uuid = "test-simulation",
+        EgateSimulationRequest(
+          startDate = UtcDate(2023, 10, 1),
+          endDate = UtcDate(2023, 10, 2),
+          terminal = T1,
+          uptakePercentage = 75.0,
+          parentChildRatio = 1.5,
+        ),
+        status = "active",
+        createdAt = SDate("2023-10-01T12:00:00Z"),
+      )
+
+      val row = EgateSimulationSerialisation(simulation)
+      val deserializedSimulation = EgateSimulationSerialisation(row)
+
+      assert(deserializedSimulation == simulation)
+    }
+  }
+}

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisationTest.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisationTest.scala
@@ -1,6 +1,7 @@
 package uk.gov.homeoffice.drt.db.serialisers
 
 import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.homeoffice.drt.ports.PortCode
 import uk.gov.homeoffice.drt.ports.Terminals.T1
 import uk.gov.homeoffice.drt.time.{SDate, UtcDate}
 
@@ -10,17 +11,21 @@ class EgateSimulationSerialisationTest extends AnyWordSpec {
       val simulation = EgateSimulation(
         uuid = "test-simulation",
         EgateSimulationRequest(
+          portCode = PortCode("LHR"),
+          terminal = T1,
           startDate = UtcDate(2023, 10, 1),
           endDate = UtcDate(2023, 10, 2),
-          terminal = T1,
           uptakePercentage = 75.0,
           parentChildRatio = 1.5,
         ),
         status = "active",
         response = Some(EgateSimulationResponse(
           "simulation content",
-          averageDifference = 10.0,
+          meanAbsolutePercentageError = 10.0,
           standardDeviation = 2.0,
+          bias = 0.5,
+          correlationCoefficient = 0.95,
+          rSquaredError = 0.9,
         )),
         createdAt = SDate("2023-10-01T12:00:00Z"),
       )

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisationTest.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisationTest.scala
@@ -17,7 +17,11 @@ class EgateSimulationSerialisationTest extends AnyWordSpec {
           parentChildRatio = 1.5,
         ),
         status = "active",
-        content = Some("simulation content"),
+        response = Some(EgateSimulationResponse(
+          "simulation content",
+          averageDifference = 10.0,
+          standardDeviation = 2.0,
+        )),
         createdAt = SDate("2023-10-01T12:00:00Z"),
       )
 

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisationTest.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/db/serialisers/EgateSimulationSerialisationTest.scala
@@ -17,6 +17,7 @@ class EgateSimulationSerialisationTest extends AnyWordSpec {
           parentChildRatio = 1.5,
         ),
         status = "active",
+        content = Some("simulation content"),
         createdAt = SDate("2023-10-01T12:00:00Z"),
       )
 

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/ports/Queues.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/ports/Queues.scala
@@ -25,14 +25,16 @@ object Queues {
       case (_, _) => Seq()
     }
 
-    def availableFallbacks(terminal: Terminal, queue: Queue, paxType: PaxType, date: LocalDate): Seq[Queue] = {
-      val availableQueues = queues(date, terminal)
-      fallbacks((queue, paxType)).filter(availableQueues.contains)
-    }
+    def availableFallbacks(terminal: Terminal): (Queue, PaxType, LocalDate) => Seq[Queue] =
+      (queue, paxType, date) => {
+        val availableQueues = queues(date, terminal)
+        fallbacks((queue, paxType)).filter(availableQueues.contains)
+      }
   }
 
   sealed trait Queue extends ClassNameForToString with Ordered[Queue] {
     override def compare(that: Queue): Int = toString.compareTo(that.toString)
+
     val stringValue: String
   }
 


### PR DESCRIPTION
Add Egate simulation db support
 - table
 - dao
 - serialisation
 - tests

Add tests around BorderCrossingDao
Update to accept LocalDate or UtcDate for queries
Add tests around Local vs Utc for flight pcp query