### PR TITLE
DRTII-1950 Add slack & http clients

### DIFF
--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/ProdHttpClient.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/ProdHttpClient.scala
@@ -1,0 +1,51 @@
+package uk.gov.homeoffice.drt
+
+import org.apache.pekko.http.scaladsl.model.HttpHeader.ParsingResult.Ok
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.headers.Accept
+import org.apache.pekko.stream.Materializer
+import org.slf4j.{Logger, LoggerFactory}
+import uk.gov.homeoffice.drt.HttpClient.rolesToRoleHeader
+import uk.gov.homeoffice.drt.auth.Roles
+import uk.gov.homeoffice.drt.auth.Roles.Role
+import uk.gov.homeoffice.drt.ports.PortCode
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait HttpClient {
+  val log: Logger = LoggerFactory.getLogger(getClass)
+
+  def send(httpRequest: HttpRequest): Future[HttpResponse]
+
+  def httpRequestForPortCsv(uri: String, portCode: PortCode): HttpRequest = {
+    val roleHeaders = rolesToRoleHeader(List(
+      Option(Roles.ArrivalsAndSplitsView), Option(Roles.ApiView), Roles.parse(portCode.iata)
+    ).flatten)
+    HttpRequest(
+      method = HttpMethods.GET,
+      uri = uri,
+      headers = roleHeaders :+ Accept(MediaTypes.`text/csv`)
+    )
+  }
+}
+
+object HttpClient {
+  def rolesToRoleHeader(roles: Iterable[Role]): List[HttpHeader] = {
+    val roleHeader: Option[HttpHeader] = HttpHeader
+      .parse("X-Forwarded-Groups", roles.map(_.name.toLowerCase).mkString(",")) match {
+      case Ok(header, _) => Option(header)
+      case _ => None
+    }
+    roleHeader.toList
+  }
+}
+
+case class ProdHttpClient(sendHttpRequest: HttpRequest => Future[HttpResponse])(implicit val ec: ExecutionContext, val mat: Materializer) extends HttpClient {
+  def send(httpRequest: HttpRequest): Future[HttpResponse] =
+    sendHttpRequest(httpRequest)
+      .recover {
+        case e: Throwable =>
+          log.error(s"Failed to connect to ${httpRequest.uri}. ${e.getMessage}")
+          throw e
+      }
+}

--- a/jvm/src/main/scala/uk/gov/homeoffice/drt/notifications/SlackClient.scala
+++ b/jvm/src/main/scala/uk/gov/homeoffice/drt/notifications/SlackClient.scala
@@ -1,0 +1,34 @@
+package uk.gov.homeoffice.drt.notifications
+
+import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest, HttpResponse}
+import org.apache.pekko.stream.Materializer
+import org.slf4j.LoggerFactory
+import uk.gov.homeoffice.drt.HttpClient
+
+import scala.concurrent.ExecutionContext
+
+trait SlackClient {
+  def notify(message: String)(implicit ec: ExecutionContext, mat: Materializer): Unit
+}
+
+object NoopSlackClient extends SlackClient {
+  def notify(message: String)(implicit ec: ExecutionContext, mat: Materializer): Unit = ()
+}
+
+case class SlackClientImpl(httpClient: HttpClient, webhookUrl: String) extends SlackClient {
+  private val log = LoggerFactory.getLogger(getClass)
+
+  def notify(message: String)(implicit ec: ExecutionContext, mat: Materializer): Unit = {
+    val payload = s"""{"text": "$message"}"""
+    val entity = HttpEntity(ContentTypes.`application/json`, payload)
+
+    httpClient.send(HttpRequest(method = HttpMethods.POST, uri = webhookUrl, entity = entity)).onComplete({
+      case scala.util.Success(HttpResponse(_, _, entity, _)) =>
+        entity.dataBytes.runReduce(_ ++ _).foreach { body =>
+          log.info(s"Slack response: ${body.utf8String}")
+        }
+      case scala.util.Failure(t) =>
+        log.error(s"Error while sending slack message: $message", t)
+    })
+  }
+}

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/ProdHttpClientTest.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/ProdHttpClientTest.scala
@@ -1,0 +1,47 @@
+package uk.gov.homeoffice.drt
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.{HttpRequest, StatusCodes}
+import org.apache.pekko.stream.Materializer
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.homeoffice.drt.auth.Roles
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+class ProdHttpClientTest extends AnyWordSpec with Matchers {
+  "ProdHttpClient" should {
+    "create a role header from a list of roles" in {
+      val roles = List(Roles.ApiView, Roles.ArrivalsAndSplitsView, Roles.LHR)
+      val headers = HttpClient.rolesToRoleHeader(roles)
+      headers.length shouldBe 1
+      headers.head.name() shouldBe "X-Forwarded-Groups"
+      headers.head.value() shouldBe "api:view,arrivals-and-splits:view,lhr"
+    }
+
+    "create an empty X-Forwarded-Groups header when given an empty list of roles" in {
+      val roles = List()
+      val headers = HttpClient.rolesToRoleHeader(roles)
+      headers.length shouldBe 1
+      headers.head.name() shouldBe "X-Forwarded-Groups"
+      headers.head.value() shouldBe ""
+    }
+
+    "send an http request" in {
+      implicit val system: ActorSystem = ActorSystem()
+      implicit val mat: Materializer = Materializer(system)
+
+      val client = ProdHttpClient(request => Http().singleRequest(request))
+      val request = HttpRequest(uri = "https://httpbin.org/get")
+      val responseFuture = client.send(request)
+      val response = Await.result(responseFuture, 10.seconds)
+
+      response.status shouldBe StatusCodes.OK
+
+      system.terminate()
+    }
+  }
+}

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/notifications/SlackClientImplTest.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/notifications/SlackClientImplTest.scala
@@ -3,6 +3,7 @@ package uk.gov.homeoffice.drt.notifications
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.apache.pekko.stream.Materializer
+import org.apache.pekko.testkit.TestProbe
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.homeoffice.drt.HttpClient
@@ -21,7 +22,7 @@ class SlackClientImplTest extends AnyWordSpec with Matchers {
     "send a message via a mock httpclient" in {
       implicit val system: ActorSystem = ActorSystem()
       implicit val mat: Materializer = Materializer.matFromSystem(ActorSystem())
-      val probe = org.apache.pekko.testkit.TestProbe()
+      val probe = TestProbe()
 
       val mockHttpClient = new HttpClient {
         override def send(httpRequest: org.apache.pekko.http.scaladsl.model.HttpRequest): Future[HttpResponse] = {

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/notifications/SlackClientImplTest.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/notifications/SlackClientImplTest.scala
@@ -1,0 +1,34 @@
+package uk.gov.homeoffice.drt.notifications
+
+import org.apache.pekko.actor.ActorSystem
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.homeoffice.drt.HttpClient
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class SlackClientImplTest extends AnyWordSpec with Matchers {
+  "SlackClientImpl" should {
+    "be instantiable" in {
+      val slackClient = SlackClientImpl(null, "http://example.com/webhook")
+      slackClient.webhookUrl shouldBe "http://example.com/webhook"
+    }
+    "send a message via a mock httpclient" in {
+      implicit val system: ActorSystem = org.apache.pekko.actor.ActorSystem()
+      implicit val mat: org.apache.pekko.stream.Materializer = org.apache.pekko.stream.Materializer.matFromSystem(org.apache.pekko.actor.ActorSystem())
+      val probe = org.apache.pekko.testkit.TestProbe()
+
+      val mockHttpClient = new HttpClient {
+        override def send(httpRequest: org.apache.pekko.http.scaladsl.model.HttpRequest): scala.concurrent.Future[org.apache.pekko.http.scaladsl.model.HttpResponse] = {
+          httpRequest.entity.dataBytes.runFold("")(_ + _.utf8String).map(body => probe.ref ! body)
+          Future.successful(org.apache.pekko.http.scaladsl.model.HttpResponse())
+        }
+      }
+      val slackClient = SlackClientImpl(mockHttpClient, "http://example.com/webhook")
+      slackClient.notify("Test message")
+      val messageSent = probe.expectMsgType[String]
+      messageSent should include("Test message")
+    }
+  }
+}

--- a/jvm/src/test/scala/uk/gov/homeoffice/drt/notifications/SlackClientImplTest.scala
+++ b/jvm/src/test/scala/uk/gov/homeoffice/drt/notifications/SlackClientImplTest.scala
@@ -1,6 +1,8 @@
 package uk.gov.homeoffice.drt.notifications
 
 import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.HttpResponse
+import org.apache.pekko.stream.Materializer
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.homeoffice.drt.HttpClient
@@ -10,22 +12,24 @@ import scala.concurrent.Future
 
 class SlackClientImplTest extends AnyWordSpec with Matchers {
   "SlackClientImpl" should {
+    val url = "http://example.com/webhook"
+
     "be instantiable" in {
-      val slackClient = SlackClientImpl(null, "http://example.com/webhook")
-      slackClient.webhookUrl shouldBe "http://example.com/webhook"
+      val slackClient = SlackClientImpl(null, url)
+      slackClient.webhookUrl shouldBe url
     }
     "send a message via a mock httpclient" in {
-      implicit val system: ActorSystem = org.apache.pekko.actor.ActorSystem()
-      implicit val mat: org.apache.pekko.stream.Materializer = org.apache.pekko.stream.Materializer.matFromSystem(org.apache.pekko.actor.ActorSystem())
+      implicit val system: ActorSystem = ActorSystem()
+      implicit val mat: Materializer = Materializer.matFromSystem(ActorSystem())
       val probe = org.apache.pekko.testkit.TestProbe()
 
       val mockHttpClient = new HttpClient {
-        override def send(httpRequest: org.apache.pekko.http.scaladsl.model.HttpRequest): scala.concurrent.Future[org.apache.pekko.http.scaladsl.model.HttpResponse] = {
+        override def send(httpRequest: org.apache.pekko.http.scaladsl.model.HttpRequest): Future[HttpResponse] = {
           httpRequest.entity.dataBytes.runFold("")(_ + _.utf8String).map(body => probe.ref ! body)
           Future.successful(org.apache.pekko.http.scaladsl.model.HttpResponse())
         }
       }
-      val slackClient = SlackClientImpl(mockHttpClient, "http://example.com/webhook")
+      val slackClient = SlackClientImpl(mockHttpClient, url)
       slackClient.notify("Test message")
       val messageSent = probe.expectMsgType[String]
       messageSent should include("Test message")

--- a/shared/src/main/scala/uk/gov/homeoffice/drt/ports/AirportConfig.scala
+++ b/shared/src/main/scala/uk/gov/homeoffice/drt/ports/AirportConfig.scala
@@ -107,7 +107,9 @@ case class AirportConfig(portCode: PortCode,
 
   def maxDesksForTerminal24Hrs(tn: Terminal): Map[Queue, IndexedSeq[Int]] = minMaxDesksByTerminalQueue24Hrs.getOrElse(tn, Map()).mapValues(_._2.toIndexedSeq).view.toMap
 
-  val terminals: LocalDate => Iterable[Terminal] = QueueConfig.terminalsForDate(queuesByTerminal)
+  val terminalsForDate: LocalDate => Iterable[Terminal] = QueueConfig.terminalsForDate(queuesByTerminal)
+
+  val terminalsForDateRange: (LocalDate, LocalDate) => Iterable[Terminal] = QueueConfig.terminalsForDateRange(queuesByTerminal)
 
   val terminalSplitQueueTypes: Map[Terminal, Set[Queue]] = terminalPaxSplits.map {
     case (terminal, splitRatios) =>


### PR DESCRIPTION
Move http client & slack client from drt-dashboard to be shared across apps